### PR TITLE
Bump to v0.2.0.

### DIFF
--- a/SwiftPhoenixClient.podspec
+++ b/SwiftPhoenixClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SwiftPhoenixClient"
-  s.version          = "0.1.0"
+  s.version          = "0.2.0"
   s.summary          = "Connect your Phoenix and iOS applications through WebSockets!"
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This is in preparation to push to CocoaPods Trunk service.

I don't think this PR includes the "Release" (and tag) to version 0.2.0. The previous release was 0.1.0, so I just incremented. I think the tag is required for the pod spec to make sense (and it currently references v0.2.0 in this PR).

The [CocoaPods Trunk docs](https://guides.cocoapods.org/making/getting-setup-with-trunk) are short and sweet, so I think this just needs to get pushed to "Trunk." I didn't see any additional steps (except for this update to the PodSpec and the Release tag).

I think you just need to register your device (from where you will push repo changes), and then push the pod spec:
````bash
$ pod trunk register ...
$ pod trunk push SwiftPhoenixClient.podspec
````

I didn't want to push to CocoaPods myself, as the first pusher becomes the owner. If you like, you can give maintainers access after you make the initial push. But, only if you want to, no pressure really :) (happy to help though):
````bash
$ pod trunk add-owner SwiftPhoenixClient ...
````

After that I think we have a live CocoaPod!