### PR TITLE
Small fix to match podspec release version to git tag

### DIFF
--- a/SwiftPhoenixClient.podspec
+++ b/SwiftPhoenixClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SwiftPhoenixClient"
-  s.version          = "0.2.0"
+  s.version          = "0.2"
   s.summary          = "Connect your Phoenix and iOS applications through WebSockets!"
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Change to match the release tag on the master GitHub branch, because the CocoaPods linter cares.
You can run the linter by doing:
`$ pod spec lint --verbose SwiftPhoenixClient.podspec`

(while in the root of the project)