### PR TITLE
Make leave methods public and fix leave method to use phx_leave event

### DIFF
--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -102,7 +102,7 @@ public struct Phoenix {
       socket?.send(payload)
     }
     
-    func leave(message: Phoenix.Message) {
+    public func leave(message: Phoenix.Message) {
       if let sock = socket {
         sock.leave(topic: topic!, message: message)
       }
@@ -135,7 +135,7 @@ public struct Phoenix {
     var heartbeatTimer: NSTimer?
     let heartbeatAfterSec = 30
     var messageReference: UInt64 = UInt64.min // 0 (max: 18,446,744,073,709,551,615)
-
+    
     public init(domainAndPort:String, path:String, transport:String, prot:String = "http") {
       self.endPoint = Path.endpointWithProtocol(prot, domainAndPort: domainAndPort, path: path, transport: transport)
       super.init()
@@ -200,7 +200,7 @@ public struct Phoenix {
     
     func rejoin(chan: Phoenix.Channel) {
       chan.reset()
-      let joinMessage = Phoenix.Message(subject: "status", body: "joining")
+      let joinMessage = chan.message ?? Phoenix.Message(subject: "status", body: "joining")
       let payload = Phoenix.Payload(topic: chan.topic!, event: "phx_join", message: joinMessage)
       send(payload)
       chan.callback(chan)
@@ -215,9 +215,8 @@ public struct Phoenix {
       }
     }
     
-    func leave(topic  topic: String, message: Phoenix.Message) {
-      let leavingMessage = Phoenix.Message(subject: "status", body: "leaving")
-      let payload = Phoenix.Payload(topic: topic, event: "leave", message: leavingMessage)
+    public func leave(topic  topic: String, message: Phoenix.Message) {
+      let payload = Phoenix.Payload(topic: topic, event: "phx_leave", message: message)
       send(payload)
       var newChannels: [Phoenix.Channel] = []
       for chan in channels {
@@ -277,7 +276,7 @@ public struct Phoenix {
       let (topic, event) = (
         unwrappedJsonString(json["topic"].asString),
         unwrappedJsonString(json["event"].asString)
-      )
+        )
       let msg: [String: AnyObject] = json["payload"].asDictionary!
       
       let messagePayload = Phoenix.Payload(topic: topic, event: event, message: Phoenix.Message(message: msg))

--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -10,25 +10,25 @@ import Foundation
 import Starscream
 
 public struct Phoenix {
-  
+
   // MARK: Phoenix Message
   public class Message: Serializable {
     var subject: String?
     var body: AnyObject?
     public var message: AnyObject?
-    
+
     public init(subject: String, body: AnyObject) {
       (self.subject, self.body) = (subject, body)
       super.init()
       create()
     }
-    
+
     public init(message: AnyObject) {
       self.message = message
       super.init()
       create(false)
     }
-    
+
     func create(single: Bool = true) -> [String: AnyObject] {
       if single {
         return [self.subject!: self.body!]
@@ -37,22 +37,22 @@ public struct Phoenix {
       }
     }
   }
-  
+
   // MARK: Phoenix Binding
   class Binding {
     var event: String
     var callback: AnyObject -> Void?
-    
+
     init(event: String, callback: AnyObject -> Void?) {
       (self.event, self.callback) = (event, callback)
       create()
     }
-    
+
     func create() -> (String, AnyObject -> Void?) {
       return (event, callback)
     }
   }
-  
+
   // MARK: Phoenix Channel
   public class Channel {
     var bindings: [Phoenix.Binding] = []
@@ -60,24 +60,24 @@ public struct Phoenix {
     var message: Phoenix.Message?
     var callback: (AnyObject -> Void?)
     var socket: Phoenix.Socket?
-    
+
     init(topic: String, message: Phoenix.Message, callback: (AnyObject -> Void), socket: Phoenix.Socket) {
       (self.topic, self.message, self.callback, self.socket) = (topic, message, { callback($0) }, socket)
       reset()
     }
-    
+
     func reset() {
       bindings = []
     }
-    
+
     public func on(event: String, callback: (AnyObject -> Void)) {
       bindings.append(Phoenix.Binding(event: event, callback: { callback($0) }))
     }
-    
+
     func isMember(topic  topic: String) -> Bool {
       return self.topic == topic
     }
-    
+
     func off(event: String) {
       var newBindings: [Phoenix.Binding] = []
       for binding in bindings {
@@ -87,7 +87,7 @@ public struct Phoenix {
       }
       bindings = newBindings
     }
-    
+
     func trigger(triggerEvent: String, msg: Phoenix.Message) {
       for binding in bindings {
         if binding.event == triggerEvent {
@@ -95,13 +95,13 @@ public struct Phoenix {
         }
       }
     }
-    
+
     func send(event: String, message: Phoenix.Message) {
       print("conn sending")
       let payload = Phoenix.Payload(topic: topic!, event: event, message: message)
       socket?.send(payload)
     }
-    
+
     public func leave(message: Phoenix.Message) {
       if let sock = socket {
         sock.leave(topic: topic!, message: message)
@@ -109,19 +109,19 @@ public struct Phoenix {
       reset()
     }
   }
-  
+
   // MARK: Phoenix Payload
   public class Payload {
     var topic: String
     var event: String
     var message: Phoenix.Message
-    
+
     public init(topic: String, event: String, message: Phoenix.Message) {
       (self.topic, self.event, self.message) = (topic, event, message)
     }
-    
+
   }
-  
+
   // MARK: Phoenix Socket
   public class Socket: NSObject, WebSocketDelegate {
     var conn: WebSocket?
@@ -135,14 +135,14 @@ public struct Phoenix {
     var heartbeatTimer: NSTimer?
     let heartbeatAfterSec = 30
     var messageReference: UInt64 = UInt64.min // 0 (max: 18,446,744,073,709,551,615)
-    
+
     public init(domainAndPort:String, path:String, transport:String, prot:String = "http") {
       self.endPoint = Path.endpointWithProtocol(prot, domainAndPort: domainAndPort, path: path, transport: transport)
       super.init()
       resetBufferTimer()
       reconnect()
     }
-    
+
     func close(callback: () -> ()) {
       if let connection = self.conn {
         connection.delegate = nil
@@ -150,7 +150,7 @@ public struct Phoenix {
       }
       callback()
     }
-    
+
     func reconnect() {
       close() {
         self.conn = WebSocket(url: NSURL(string: self.endPoint!)!)
@@ -160,44 +160,44 @@ public struct Phoenix {
         }
       }
     }
-    
+
     func resetBufferTimer() {
       sendBufferTimer?.invalidate()
       sendBufferTimer = NSTimer.scheduledTimerWithTimeInterval(NSTimeInterval(flushEverySec), target: self, selector: Selector("flushSendBuffer"), userInfo: nil, repeats: true)
     }
-    
+
     func onOpen() {
       reconnectTimer?.invalidate()
       heartbeatTimer?.invalidate()
       heartbeatTimer = NSTimer.scheduledTimerWithTimeInterval(NSTimeInterval(heartbeatAfterSec), target: self, selector: Selector("sendHeartbeat"), userInfo: nil, repeats: true)
       rejoinAll()
     }
-    
+
     func onClose(event: String) {
       heartbeatTimer?.invalidate()
       reconnectTimer?.invalidate()
       reconnectTimer = NSTimer.scheduledTimerWithTimeInterval(NSTimeInterval(reconnectAfterSec), target: self, selector: Selector("reconnect"), userInfo: nil, repeats: true)
     }
-    
+
     func onError(error: NSError) {
       print("Error: \(error)")
     }
-    
+
     func isConnected() -> Bool {
       if let connection = self.conn {
         return connection.isConnected
       } else {
         return false
       }
-      
+
     }
-    
+
     func rejoinAll() {
       for chan in channels {
         rejoin(chan as Phoenix.Channel)
       }
     }
-    
+
     func rejoin(chan: Phoenix.Channel) {
       chan.reset()
       let joinMessage = chan.message ?? Phoenix.Message(subject: "status", body: "joining")
@@ -205,7 +205,7 @@ public struct Phoenix {
       send(payload)
       chan.callback(chan)
     }
-    
+
     public func join(topic  topic: String, message: Phoenix.Message, callback: (AnyObject -> Void)) {
       let chan = Phoenix.Channel(topic: topic, message: message, callback: callback, socket: self)
       channels.append(chan)
@@ -214,7 +214,7 @@ public struct Phoenix {
         rejoin(chan)
       }
     }
-    
+
     public func leave(topic  topic: String, message: Phoenix.Message) {
       let payload = Phoenix.Payload(topic: topic, event: "phx_leave", message: message)
       send(payload)
@@ -227,7 +227,7 @@ public struct Phoenix {
       }
       channels = newChannels
     }
-    
+
     public func send(data: Phoenix.Payload) {
       if isConnected() {
         doSendBuffer(data)
@@ -235,7 +235,7 @@ public struct Phoenix {
         sendBuffer.append(data)
       }
     }
-    
+
     func flushSendBuffer() {
       if isConnected() && sendBuffer.count > 0 {
         for data in sendBuffer {
@@ -245,7 +245,7 @@ public struct Phoenix {
         resetBufferTimer()
       }
     }
-    
+
     func doSendBuffer(data: Phoenix.Payload) {
       if let connection = self.conn {
         let json = self.payloadToJson(data)
@@ -253,13 +253,13 @@ public struct Phoenix {
         connection.writeString(json)
       }
     }
-    
+
     func sendHeartbeat() {
       let heartbeatMessage = Phoenix.Message(subject: "status", body: "heartbeat")
       let payload = Phoenix.Payload(topic: "phoenix", event: "heartbeat", message: heartbeatMessage)
       send(payload)
     }
-    
+
     func onMessage(payload: Phoenix.Payload) {
       let (topic, event, message) = (payload.topic, payload.event, payload.message)
       for chan in channels {
@@ -268,7 +268,7 @@ public struct Phoenix {
         }
       }
     }
-    
+
     // WebSocket Delegate Methods
     public func websocketDidReceiveMessage(socket: WebSocket, text: String) {
       print("socket message: \(text)")
@@ -276,31 +276,31 @@ public struct Phoenix {
       let (topic, event) = (
         unwrappedJsonString(json["topic"].asString),
         unwrappedJsonString(json["event"].asString)
-        )
+      )
       let msg: [String: AnyObject] = json["payload"].asDictionary!
-      
+
       let messagePayload = Phoenix.Payload(topic: topic, event: event, message: Phoenix.Message(message: msg))
       onMessage(messagePayload)
     }
-    
+
     public func websocketDidReceiveData(socket: WebSocket, data: NSData) {
       print("got some data: \(data.length)")
     }
-    
+
     public func websocketDidDisconnect(socket: WebSocket, error: NSError?) {
       print("socket closed: \(error?.localizedDescription)")
       onClose("reason: \(error?.localizedDescription)")
     }
-    
+
     public func websocketDidConnect(socket: WebSocket) {
       print("socket opened")
       onOpen()
     }
-    
+
     public func websocketDidWriteError(error: NSError?) {
       onError(error!)
     }
-    
+
     func unwrappedJsonString(string: String?) -> String {
       if let stringVal = string {
         return stringVal
@@ -308,13 +308,13 @@ public struct Phoenix {
         return ""
       }
     }
-    
+
     func makeRef() -> UInt64 {
       let newRef = messageReference + 1
       messageReference = (newRef == UINT64_MAX) ? 0 : newRef
       return newRef
     }
-    
+
     func payloadToJson(payload: Phoenix.Payload) -> String {
       let ref = makeRef()
       var json = "{\"topic\": \"\(payload.topic)\", \"event\": \"\(payload.event)\", \"ref\": \"\(ref)\", "
@@ -326,7 +326,7 @@ public struct Phoenix {
         json += "\"payload\": \(payload.message.toJsonString())"
       }
       json += "}"
-      
+
       return json
     }
   }


### PR DESCRIPTION
Provides the ability to leave a channel to the client, and fixes the implemented leave method to use the correct leave event (`phx_leave`).

There's some whitespace cleanup in the commits, and fixes indentation to 2-spaces where some commits left 4. Perhaps we need a style guide to follow? Or at least an .editorconfig file.