### PR TITLE
Fix retain cycle, channel should not retain socket

### DIFF
--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -94,7 +94,7 @@ public struct Phoenix {
     var topic: String?
     var message: Phoenix.Message?
     var callback: (AnyObject -> Void?)
-    var socket: Phoenix.Socket?
+    weak var socket: Phoenix.Socket?
     
     /**
      Initializes a new Phoenix.Channel mapping to a server-side channel


### PR DESCRIPTION
There is a retain cycle, because a channel holds a strong reference to the socket and the socket has an array of channels as a strong reference.
In order to fix this we can make the channel hold a weak reference to the socket.