### PR TITLE
Fix heartbeatTimer not firing

### DIFF
--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -282,7 +282,14 @@ public struct Phoenix {
      */
     func startHeartbeatTimer() {
       heartbeatTimer.invalidate()
-      heartbeatTimer = NSTimer.scheduledTimerWithTimeInterval(heartbeatDelay, target: self, selector: #selector(Phoenix.Socket.heartbeat), userInfo: nil, repeats: true)
+        dispatch_async(dispatch_get_main_queue()) {
+            self.heartbeatTimer = NSTimer.scheduledTimerWithTimeInterval(
+                self.heartbeatDelay,
+                target: self,
+                selector: #selector(self.heartbeat),
+                userInfo: nil,
+                repeats: true)
+        }
     }
     
     /**


### PR DESCRIPTION
The `heartbeatTimer` was not firing due to threading issues. Fixed by now being instantiated on the main thread.