### PR TITLE
Fix channel join message

### DIFF
--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -377,7 +377,7 @@ public struct Phoenix {
      */
     func rejoin(chan: Phoenix.Channel) {
       chan.reset()
-      if let topic = chan.topic, joinMessage = chan.joinMessage {
+      if let topic = chan.topic, joinMessage = chan.message {
           let payload = Phoenix.Payload(topic: topic, event: "phx_join", message: joinMessage)
           send(payload)
           chan.callback(chan)

--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -10,19 +10,19 @@ import Foundation
 import Starscream
 
 public struct Phoenix {
-  
+
   // MARK: Phoenix Message
   public class Message: Serializable {
     var subject: String?
     var body: AnyObject?
     public var message: AnyObject?
-    
+
     /**
      Initializes single entry message with a subject
-     
+
      - parameter subject: String for message key
      - parameter body:    String for message body
-     
+
      - returns: Phoenix.Message
      */
     public init(subject: String, body: AnyObject) {
@@ -30,12 +30,12 @@ public struct Phoenix {
       super.init()
       create()
     }
-    
+
     /**
      Initializes a multi key message
-     
+
      - parameter message: Dictionary containing message payload
-     
+
      - returns: Phoenix.Message
      */
     public init(message: AnyObject) {
@@ -43,12 +43,12 @@ public struct Phoenix {
       super.init()
       create(false)
     }
-    
+
     /**
      Creates a new single or multi key message
-     
+
      - parameter single: Boolean indicating if the message is a single key or not
-     
+
      - returns: Phoenix.Message
      */
     func create(single: Bool = true) -> [String: AnyObject] {
@@ -59,35 +59,35 @@ public struct Phoenix {
       }
     }
   }
-  
+
   // MARK: Phoenix Binding
   class Binding {
     var event: String
     var callback: AnyObject -> Void?
-    
+
     /**
      Initializes an object for handling event/callback bindings
-     
+
      - parameter event:    String indicating event name
      - parameter callback: Function to run on given event
-     
+
      - returns: Tuple containing event and callback function
      */
     init(event: String, callback: AnyObject -> Void?) {
       (self.event, self.callback) = (event, callback)
       create()
     }
-    
+
     /**
      Creates a Phoenix.Binding object holding event/callback details
-     
+
      - returns: Tuple containing event and callback function
      */
     func create() -> (String, AnyObject -> Void?) {
       return (event, callback)
     }
   }
-  
+
   // MARK: Phoenix Channel
   public class Channel {
     var bindings: [Phoenix.Binding] = []
@@ -95,53 +95,53 @@ public struct Phoenix {
     var message: Phoenix.Message?
     var callback: (AnyObject -> Void?)
     weak var socket: Phoenix.Socket?
-    
+
     /**
      Initializes a new Phoenix.Channel mapping to a server-side channel
-     
+
      - parameter topic:    String topic for given channel
      - parameter message:  Phoenix.Message object containing message to send
      - parameter callback: Function to pass along with the channel instance
      - parameter socket:   Phoenix.Socket for websocket connection
-     
+
      - returns: Phoenix.Channel
      */
     init(topic: String, message: Phoenix.Message, callback: (AnyObject -> Void), socket: Phoenix.Socket) {
       (self.topic, self.message, self.callback, self.socket) = (topic, message, { callback($0) }, socket)
       reset()
     }
-    
+
     /**
      Removes existing bindings
      */
     func reset() {
       bindings = []
     }
-    
+
     /**
      Assigns Binding events to the channel bindings array
-     
+
      - parameter event:    String event name
      - parameter callback: Function to run on event
      */
     public func on(event: String, callback: (AnyObject -> Void)) {
       bindings.append(Phoenix.Binding(event: event, callback: { callback($0) }))
     }
-    
+
     /**
      Determine if a topic belongs in this channel
-     
+
      - parameter topic: String topic name for comparison
-     
+
      - returns: Boolean
      */
     func isMember(topic  topic: String) -> Bool {
       return self.topic == topic
     }
-    
+
     /**
      Removes an event binding from this cahnnel
-     
+
      - parameter event: String event name
      */
     func off(event: String) {
@@ -153,10 +153,10 @@ public struct Phoenix {
       }
       bindings = newBindings
     }
-    
+
     /**
      Triggers an event on this channel
-     
+
      - parameter triggerEvent: String event name
      - parameter msg:          Phoenix.Message to pass into event callback
      */
@@ -167,10 +167,10 @@ public struct Phoenix {
         }
       }
     }
-    
+
     /**
      Sends and event and message through the socket
-     
+
      - parameter event:   String event name
      - parameter message: Phoenix.Message payload
      */
@@ -179,10 +179,10 @@ public struct Phoenix {
       let payload = Phoenix.Payload(topic: topic!, event: event, message: message)
       socket?.send(payload)
     }
-    
+
     /**
      Leaves the socket
-     
+
      - parameter message: Phoenix.Message to pass to the Socket#leave function
      */
     func leave(message: Phoenix.Message) {
@@ -192,54 +192,54 @@ public struct Phoenix {
       reset()
     }
   }
-  
+
   // MARK: Phoenix Payload
   public class Payload {
     var topic: String
     var event: String
     var message: Phoenix.Message
-    
+
     /**
      Initializes a formatted Phoenix.Payload
-     
+
      - parameter topic:   String topic name
      - parameter event:   String event name
      - parameter message: Phoenix.Message payload
-     
+
      - returns: Phoenix.Payload
      */
     public init(topic: String, event: String, message: Phoenix.Message) {
       (self.topic, self.event, self.message) = (topic, event, message)
     }
-    
+
   }
-  
+
   // MARK: Phoenix Socket
   public class Socket: NSObject, WebSocketDelegate {
     var conn: WebSocket?
     var endPoint: String?
     var channels: [Phoenix.Channel] = []
-    
+
     var sendBuffer: [Void] = []
     var sendBufferTimer = NSTimer()
     let flushEveryMs = 1.0
-    
+
     var reconnectTimer = NSTimer()
     let reconnectAfterMs = 1.0
-    
+
     var heartbeatTimer = NSTimer()
     let heartbeatDelay = 30.0
-    
+
     var messageReference: UInt64 = UInt64.min // 0 (max: 18,446,744,073,709,551,615)
-    
+
     /**
      Initializes a Socket connection
-     
+
      - parameter domainAndPort: Phoenix server root path and proper port
      - parameter path:          Websocket path on Phoenix Server
      - parameter transport:     Transport for Phoenix.Server - traditionally "websocket"
      - parameter prot:          Connection protocol - default is HTTP
-     
+
      - returns: Phoenix.Socket
      */
     public init(domainAndPort:String, path:String, transport:String, prot:String = "http") {
@@ -249,10 +249,10 @@ public struct Phoenix {
       startHeartbeatTimer()
       reconnect()
     }
-    
+
     /**
      Closes socket connection
-     
+
      - parameter callback: Function to run after close
      */
     public func close(callback: (() -> ()) = {}) {
@@ -263,7 +263,7 @@ public struct Phoenix {
       invalidateTimers()
       callback()
     }
-    
+
     /**
       Invalidate open timers to allow socket to be deallocated when closed
     */
@@ -271,12 +271,12 @@ public struct Phoenix {
       heartbeatTimer.invalidate()
       reconnectTimer.invalidate()
       sendBufferTimer.invalidate()
-      
+
       heartbeatTimer = NSTimer()
       reconnectTimer = NSTimer()
       sendBufferTimer = NSTimer()
     }
-    
+
     /**
      Initializes a 30s timer to let Phoenix know this device is still alive
      */
@@ -284,7 +284,7 @@ public struct Phoenix {
       heartbeatTimer.invalidate()
       heartbeatTimer = NSTimer.scheduledTimerWithTimeInterval(heartbeatDelay, target: self, selector: #selector(Phoenix.Socket.heartbeat), userInfo: nil, repeats: true)
     }
-    
+
     /**
      Heartbeat payload (Phoenix.Message) to send with each pulse
      */
@@ -293,7 +293,7 @@ public struct Phoenix {
       let payload = Phoenix.Payload(topic: "phoenix", event: "heartbeat", message: message)
       send(payload)
     }
-    
+
     /**
      Reconnects to a closed socket connection
      */
@@ -306,7 +306,7 @@ public struct Phoenix {
         }
       }
     }
-    
+
     /**
      Resets the message buffer timer and invalidates any existing ones
      */
@@ -315,7 +315,7 @@ public struct Phoenix {
       sendBufferTimer = NSTimer.scheduledTimerWithTimeInterval(flushEveryMs, target: self, selector: #selector(Phoenix.Socket.flushSendBuffer), userInfo: nil, repeats: true)
       sendBufferTimer.fire()
     }
-    
+
     /**
      Kills reconnect timer and joins all open channels
      */
@@ -323,20 +323,20 @@ public struct Phoenix {
       reconnectTimer.invalidate()
       rejoinAll()
     }
-    
+
     /**
      Starts reconnect timer onClose
-     
+
      - parameter event: String event name
      */
     func onClose(event: String) {
       reconnectTimer.invalidate()
       reconnectTimer = NSTimer.scheduledTimerWithTimeInterval(reconnectAfterMs, target: self, selector: #selector(Phoenix.Socket.reconnect), userInfo: nil, repeats: true)
     }
-    
+
     /**
      Triggers error event
-     
+
      - parameter error: NSError
      */
     func onError(error: NSError) {
@@ -346,10 +346,10 @@ public struct Phoenix {
         chan.trigger("error", msg: msg)
       }
     }
-    
+
     /**
      Indicates if connection is established
-     
+
      - returns: Bool
      */
     func isConnected() -> Bool {
@@ -358,9 +358,9 @@ public struct Phoenix {
       } else {
         return false
       }
-      
+
     }
-    
+
     /**
      Rejoins all Phoenix.Channel instances
      */
@@ -369,23 +369,24 @@ public struct Phoenix {
         rejoin(chan as Phoenix.Channel)
       }
     }
-    
+
     /**
      Rejoins a given Phoenix Channel
-     
+
      - parameter chan: Phoenix.Channel
      */
     func rejoin(chan: Phoenix.Channel) {
       chan.reset()
-      let joinMessage = Phoenix.Message(subject: "status", body: "joining")
-      let payload = Phoenix.Payload(topic: chan.topic!, event: "phx_join", message: joinMessage)
-      send(payload)
-      chan.callback(chan)
+      if let topic = chan.topic, joinMessage = chan.joinMessage {
+          let payload = Phoenix.Payload(topic: topic, event: "phx_join", message: joinMessage)
+          send(payload)
+          chan.callback(chan)
+      }
     }
-    
+
     /**
      Joins socket
-     
+
      - parameter topic:    String topic name
      - parameter message:  Phoenix.Message payload
      - parameter callback: Function to trigger after join
@@ -398,10 +399,10 @@ public struct Phoenix {
         rejoin(chan)
       }
     }
-    
+
     /**
      Leave open socket
-     
+
      - parameter topic:   String topic name
      - parameter message: Phoenix.Message payload
      */
@@ -418,10 +419,10 @@ public struct Phoenix {
       }
       channels = newChannels
     }
-    
+
     /**
      Send payload over open socket
-     
+
      - parameter data: Phoenix.Payload
      */
     public func send(data: Phoenix.Payload) {
@@ -439,7 +440,7 @@ public struct Phoenix {
         sendBuffer.append(callback(data))
       }
     }
-    
+
     /**
      Flush message buffer
      */
@@ -452,10 +453,10 @@ public struct Phoenix {
         resetBufferTimer()
       }
     }
-    
+
     /**
      Trigger event on message received
-     
+
      - parameter payload: Phoenix.Payload
      */
     func onMessage(payload: Phoenix.Payload) {
@@ -466,7 +467,7 @@ public struct Phoenix {
         }
       }
     }
-    
+
     // WebSocket Delegate Methods
     public func websocketDidReceiveMessage(socket: WebSocket, text: String) {
       print("socket message: \(text)")
@@ -476,30 +477,30 @@ public struct Phoenix {
         unwrappedJsonString(json["event"].asString)
       )
       let msg: [String: AnyObject] = json["payload"].asDictionary!
-      
+
       let messagePayload = Phoenix.Payload(topic: topic, event: event, message: Phoenix.Message(message: msg))
       onMessage(messagePayload)
     }
-    
+
     public func websocketDidReceiveData(socket: WebSocket, data: NSData) {
       print("got some data: \(data.length)")
     }
-    
+
     public func websocketDidDisconnect(socket: WebSocket, error: NSError?) {
       if let err = error { onError(err) }
       print("socket closed: \(error?.localizedDescription)")
       onClose("reason: \(error?.localizedDescription)")
     }
-    
+
     public func websocketDidConnect(socket: WebSocket) {
       print("socket opened")
       onOpen()
     }
-    
+
     public func websocketDidWriteError(error: NSError?) {
       onError(error!)
     }
-    
+
     func unwrappedJsonString(string: String?) -> String {
       if let stringVal = string {
         return stringVal
@@ -507,13 +508,13 @@ public struct Phoenix {
         return ""
       }
     }
-    
+
     func makeRef() -> UInt64 {
       let newRef = messageReference + 1
       messageReference = (newRef == UINT64_MAX) ? 0 : newRef
       return newRef
     }
-    
+
     func payloadToJson(payload: Phoenix.Payload) -> String {
       let ref = makeRef()
       var json = "{\"topic\": \"\(payload.topic)\", \"event\": \"\(payload.event)\", \"ref\": \"\(ref)\", "
@@ -525,7 +526,7 @@ public struct Phoenix {
         json += "\"payload\": \(payload.message.toJsonString())"
       }
       json += "}"
-      
+
       return json
     }
   }


### PR DESCRIPTION
Sorry for the whitespace changes! Only just noticed. I can revert if required.

There was a regression in a82689106e074ae2ae0313c34b75a0d4c419354a where the channel join message was ignored. This fixes that (see line 380).