### PR TITLE
Start heartbeat when connection is open

### DIFF
--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -246,7 +246,6 @@ public struct Phoenix {
       self.endPoint = Path.endpointWithProtocol(prot, domainAndPort: domainAndPort, path: path, transport: transport)
       super.init()
       resetBufferTimer()
-      startHeartbeatTimer()
       reconnect()
     }
 
@@ -321,6 +320,7 @@ public struct Phoenix {
      */
     func onOpen() {
       reconnectTimer.invalidate()
+      startHeartbeatTimer()
       rejoinAll()
     }
 


### PR DESCRIPTION
The heartbeatTimer was invalidated right after it was started, because we are calling ```reconnect() -> close()``` right after ```startHeartbeatTimer``` which will invalidate all running timers.
I have moved ```startHeartbeatTimer``` to ```onOpen()```.