### PR TITLE
Add support for extra parameters to be supplied on Socket instantiation

### DIFF
--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -245,7 +245,7 @@ public struct Phoenix {
     public init(domainAndPort:String, path:String, transport:String, prot:String = "http", params: [String: AnyObject]? = nil) {
       var _endPoint = Path.endpointWithProtocol(prot, domainAndPort: domainAndPort, path: path, transport: transport)
       if params != nil{
-        _endpoint = _endpoint + "?" + params!.map({ "\($0.0)=\($0.1)" }).joinWithSeparator("&")
+        _endPoint = _endPoint + "?" + params!.map({ "\($0.0)=\($0.1)" }).joinWithSeparator("&")
       }
       self.endPoint = _endPoint
       super.init()

--- a/Pod/Classes/Phoenix.swift
+++ b/Pod/Classes/Phoenix.swift
@@ -242,8 +242,12 @@ public struct Phoenix {
 
      - returns: Phoenix.Socket
      */
-    public init(domainAndPort:String, path:String, transport:String, prot:String = "http") {
-      self.endPoint = Path.endpointWithProtocol(prot, domainAndPort: domainAndPort, path: path, transport: transport)
+    public init(domainAndPort:String, path:String, transport:String, prot:String = "http", params: [String: AnyObject]? = nil) {
+      var _endPoint = Path.endpointWithProtocol(prot, domainAndPort: domainAndPort, path: path, transport: transport)
+      if params != nil{
+        _endpoint = _endpoint + "?" + params!.map({ "\($0.0)=\($0.1)" }).joinWithSeparator("&")
+      }
+      self.endPoint = _endPoint
       super.init()
       resetBufferTimer()
       reconnect()

--- a/SwiftPhoenixClient.podspec
+++ b/SwiftPhoenixClient.podspec
@@ -46,5 +46,5 @@ http://www.phoenixframework.org/docs/channels
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'Starscream', '~> 1.0.0'
+  s.dependency 'Starscream', '~> 2.0.0'
 end


### PR DESCRIPTION
Currently when a new `Phoenix.Socket` is initialized there is no way to provide additional query parameters to be used in the final endpoint.

Sometimes it makes sense to authorize users and accept/reject a web socket connection based on  query parameters, perhaps a jwt, etc. In Elixir we would do something like this:

```elixir
# user_socket.ex

def connect(params, socket) do
  case validate_token(params["token"]) do
    true -> {:ok, socket}
    false -> :error 
  end
end 
```

And in Swift we would just supply an extra argument to the Socket initializer.
```swift

let params = ["token": "my super secret token"]
let socket = Phoenix.Socket(domainAndPort: domainAndPort, path: path, transport: transport, params: params)
```

This pull request adds support for providing query parameters to the Socket initializer.

Cheers!