### PR TITLE
set deploy target to 9.0

### DIFF
--- a/SwiftPhoenixClient.xcodeproj/project.pbxproj
+++ b/SwiftPhoenixClient.xcodeproj/project.pbxproj
@@ -371,6 +371,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.phoenixframework.SwiftPhoenixClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -391,6 +392,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.phoenixframework.SwiftPhoenixClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
By default, Xcode sets deploy target version to the version of the OS corresponding to the base SDK version and later.

Explicitly set deploy target to 9.0 so that tool carthage can build framework with correct target version and app can use this library for iOS 9.0.