### PR TITLE
Update to use Starscream 3

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -256,7 +256,7 @@ public class Socket: WebSocketDelegate {
 
     // WebSocket Delegate Methods
 
-    public func websocketDidReceiveMessage(socket: WebSocket, text: String) {
+    public func websocketDidReceiveMessage(socket: WebSocketClient, text: String) {
       Logger.debug(message: "socket message: \(text)")
 
         guard let data = text.data(using: String.Encoding.utf8),
@@ -276,17 +276,17 @@ public class Socket: WebSocketDelegate {
         onMessage(payload: messagePayload)
     }
 
-    public func websocketDidReceiveData(socket: WebSocket, data: Data) {
+    public func websocketDidReceiveData(socket: WebSocketClient, data: Data) {
       Logger.debug(message: "got some data: \(data.count)")
     }
 
-    public func websocketDidDisconnect(socket: WebSocket, error: NSError?) {
-        if let err = error { onError(error: err) }
+    public func websocketDidDisconnect(socket: WebSocketClient, error: Error?) {
+        if let err = error { onError(error: err as NSError) }
         Logger.debug(message: "socket closed: \(error?.localizedDescription ?? "Unknown error")")
         onClose(event: "reason: \(error?.localizedDescription ?? "Unknown error")")
     }
 
-    public func websocketDidConnect(socket: WebSocket) {
+    public func websocketDidConnect(socket: WebSocketClient) {
       Logger.debug(message: "socket opened")
         onOpen()
     }

--- a/SwiftPhoenixClient.podspec
+++ b/SwiftPhoenixClient.podspec
@@ -39,5 +39,5 @@ http://www.phoenixframework.org/docs/channels
 
   s.source_files = 'Sources/*.swift'
 
-  s.dependency 'Starscream', '~> 2.1.0'
+  s.dependency 'Starscream', '~> 3.0.0'
 end


### PR DESCRIPTION
Starscream 2 does not support Swift 4, while version 3 does.

Existing unit tests pass, but this probably warrants additional testing.