### PR TITLE
Updated Channel.join(timeout:) to pass along initial params on join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ This product uses [Semantic Versioning](https://semver.org/).
 
 
 ## [Unreleased]
-* Update Starscream to 3.0.4
-* Added URL based init methods
-* New init() methods no longer connect automaticlly and require calling .connect() 
-* Added status handlers when sending a message
-* Made all message payloads optional
+* Bugfix when opening a channel, initial params are not sent through
 
 
-[Unreleased]: https://github.com/davidstump/SwiftPhoenixClient/compare/0.6.0...HEAD
+
+## [0.8.0]
+* Updated Starscream to 3.0.4
+* Update officially to Swift 4
+* Update library to mirror [Phoenix.js](https://hexdocs.pm/phoenix/js/) more closely
+
+
+[Unreleased]: https://github.com/davidstump/SwiftPhoenixClient/compare/0.8.0...HEAD
+[0.8.0]: https://github.com/davidstump/SwiftPhoenixClient/compare/0.6.0...0.8.0

--- a/Sources/Channel.swift
+++ b/Sources/Channel.swift
@@ -86,8 +86,7 @@ public class Channel {
     /// - parameter timeout: Optional timeout
     /// - return: Push which can receive hooks can be applied to
     public func join(timeout: Int? = nil) -> Push {
-        return socket.push(topic: topic, event: PhoenixEvent.join)
-        
+        return socket.push(topic: topic, event: PhoenixEvent.join, payload: params)
     }
     
     /// Hook into channel close


### PR DESCRIPTION
When creating a Channel, the initializer accepts optional parameters to be passed
to the server when the Channel joins. These params were not being passed along
to the socket.join() method.

Resolves #87 