### PR TITLE
- Firing onClose when we receive an ok after leaving a channel

### DIFF
--- a/Sources/Channel.swift
+++ b/Sources/Channel.swift
@@ -136,6 +136,9 @@ public class Channel {
     @discardableResult
     public func leave(timeout: Int? = nil) -> Push {
         return socket.push(topic: topic, event: PhoenixEvent.leave)
+            .receive("ok") { [weak self] payload in
+                self?.onClose?(payload)
+            }
     }
     
     /// Overridable message hook. Receives all events for specialized message


### PR DESCRIPTION
PR to fix https://github.com/davidstump/SwiftPhoenixClient/issues/94

Fire `Channel`'s `onClose` closure when we successfully leave 