### PR TITLE
Passing in channel join parameters

### DIFF
--- a/Sources/Channel.swift
+++ b/Sources/Channel.swift
@@ -28,9 +28,6 @@ public class Channel {
     
     /// The topic of the Channel. e.g. "rooms:friends"
     public let topic: String
-    
-    /// The params sent when joining the channel
-    public let params: Payload
 
     /// The Socket that the channel belongs to
     fileprivate let socket: Socket
@@ -66,11 +63,9 @@ public class Channel {
     /// Initialize a Channel
     ///
     /// - parameter topic: Topic of the Channel
-    /// - parameter params: Parameters to send when joining. Can be nil
     /// - parameter socket: Socket that the channel is a part of
-    init(topic: String, params: [String: Any]?, socket: Socket) {
+    init(topic: String, socket: Socket) {
         self.topic = topic
-        self.params = params ?? [:]
         self.socket = socket
         
         self.onEvents = [:]
@@ -83,9 +78,10 @@ public class Channel {
     //----------------------------------------------------------------------
     /// Joins the channel
     ///
+    /// - parameter params: Parameters to send when joining. Can be nil
     /// - parameter timeout: Optional timeout
     /// - return: Push which can receive hooks can be applied to
-    public func join(timeout: Int? = nil) -> Push {
+    public func join(params: [String: Any] = [:], timeout: Int? = nil) -> Push {
         return socket.push(topic: topic, event: PhoenixEvent.join, payload: params)
     }
     

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -170,10 +170,10 @@ public class Socket {
     /// - parameter topic: Topic of the channel
     /// - parameter params: Parameters for the channel
     /// - return: A new channel
-    public func channel(_ topic: String, params: [String: Any]? = nil) -> Channel {
+    public func channel(_ topic: String) -> Channel {
         if let previousChannel = channels[topic] { return previousChannel }
         
-        let channel = Channel(topic: topic, params: params, socket: self)
+        let channel = Channel(topic: topic, socket: self)
         self.channels[topic] = channel
 
         return channel

--- a/Tests/SocketSpec.swift
+++ b/Tests/SocketSpec.swift
@@ -40,7 +40,7 @@ class SocketSpec: QuickSpec {
             fakeConnection = FakeWebSocket(url: URL(string: "http://localhost:4000/socket/websocket")!)
             socket = Socket(connection: fakeConnection)
             
-            newMsgChannel = socket.channel("new_msg", params: ["token": "abc123"])
+            newMsgChannel = socket.channel("new_msg")
             oldMsgChannel = socket.channel("old_msg")
             
         }


### PR DESCRIPTION
Currently a `Channel`'s join parameters are passed in when instantiating a Channel, making them immutable.

I think that the `params` should be passed in per `join` method instead. This allows different join parameters on a channel without having to leave/destroy a channel. 