### PR TITLE
Returning Push object when we ask a socket to remove a channel

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -158,8 +158,9 @@ public class Socket {
     /// Removes a channel from the socket
     ///
     /// - parameter channel: Channel to remove
-    public func remove(_ channel: Channel) {
-        channel.leave().receive("ok") { [weak self] (_) in
+    @discardableResult
+    public func remove(_ channel: Channel) -> Push {
+        return channel.leave().receive("ok") { [weak self] (_) in
             self?.channels.removeValue(forKey: channel.topic)
         }
     }


### PR DESCRIPTION
When we ask the socket to remove (leave) a channel, the `Push` object is now returned. This small change allows us to observe the removal and handle errors inline.

e.g.
```
socket.remove(channel)
    .receive("ok") { payload in
        ...
    }
    .receive("error") { payload in
        ...
    }
```