### PR TITLE
Expose security configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This product uses [Semantic Versioning](https://semver.org/).
 
 
 ## [Unreleased]
-
+* Exposes security properties of the underlying `WebSocket`. This allows for things like SSL Pinning, custom encyption setups, etc. 
 
 
 ## [0.9.0]

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -37,6 +37,34 @@ public class Socket {
     /// is set to true
     public var autoReconnect: Bool = true
     
+    /// Enable/Disable SSL certificate validation by setting the value on the 
+    /// underlying WebSocket.
+    /// See https://github.com/daltoniam/Starscream#self-signed-ssl
+    public var disableSSLCertValidation: Bool {
+        get { return connection.disableSSLCertValidation }
+        set { connection.disableSSLCertValidation = newValue }
+    }
+
+    #if os(Linux)
+    #else
+    /// Configure custom SSL validation logic, eg. SSL pinning, by setting the 
+    /// value on the underlyting WebSocket.
+    /// See https://github.com/daltoniam/Starscream#ssl-pinning
+    public var security: SSLTrustValidator? {
+        get { return connection.security }
+        set { connection.security = newValue }
+    }
+    
+    /// Configure the encryption used by your client by setting the allowed 
+    /// cipher suites supported by your server.
+    /// See https://github.com/daltoniam/Starscream#ssl-cipher-suites
+    public var enabledSSLCipherSuites: [SSLCipherSuite]? {
+        get { return connection.enabledSSLCipherSuites }
+        set { connection.enabledSSLCipherSuites = newValue }
+    }
+    #endif
+    
+    
     
     //----------------------------------------------------------------------
     // MARK: - Private Attributes


### PR DESCRIPTION
Exposes the security properties as discussed [here](https://github.com/davidstump/SwiftPhoenixClient/issues/106)

I didn't see any sort of contributing doc so i've looked at the existing code and have tried to follow the style used thought the codebase.  