### PR TITLE
Strong memory cycle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This product uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 * Exposes security properties of the underlying `WebSocket`. This allows for things like SSL Pinning, custom encyption setups, etc. 
-
+* Fixes leaks ([#109](https://github.com/davidstump/SwiftPhoenixClient/issues/109))
 
 ## [0.9.0]
 Continue to improve the API and behavior of the library to behave similar to the JS library. This release introduces 

--- a/Sources/Channel.swift
+++ b/Sources/Channel.swift
@@ -86,54 +86,65 @@ public class Channel {
                              payload: self.params,
                              timeout: self.timeout)
         
-        self.rejoinTimer = PhxTimer(callback: {
-            self.rejoinTimer?.scheduleTimeout()
-            if self.socket.isConnected { self.rejoin() }
-        }, timerCalc: socket.reconnectAfterMs)
+        self.rejoinTimer = PhxTimer(callback: { [weak self] in
+            guard let strongSelf = self else { return }
+            strongSelf.rejoinTimer?.scheduleTimeout()
+            if strongSelf.socket.isConnected { strongSelf.rejoin() }
+        }, timerCalc: { [weak self] tryCount in
+            self?.socket.reconnectAfterMs(tryCount) ?? 10000
+        })
         
         /// Perfom once the Channel is joined
-        self.joinPush.receive("ok") { (_) in
-            self.state = ChannelState.joined
-            self.rejoinTimer?.reset()
-            self.pushBuffer.forEach( { $0.send() })
-            self.pushBuffer = [Push]()
+        self.joinPush.receive("ok") { [weak self] (_) in
+            guard let strongSelf = self else { return }
+            strongSelf.state = ChannelState.joined
+            strongSelf.rejoinTimer?.reset()
+            strongSelf.pushBuffer.forEach( { $0.send() })
+            strongSelf.pushBuffer = [Push]()
         }
         
         /// Perfom when the Channel has been closed
-        self.onClose { (_) in
-            self.rejoinTimer?.reset()
-            self.socket.logItems("channel", "close \(self.topic)")
-            self.state = ChannelState.closed
-            self.socket.remove(self)
+        self.onClose { [weak self] (_) in
+            guard let strongSelf = self else { return }
+            strongSelf.rejoinTimer?.reset()
+            strongSelf.socket.logItems("channel", "close \(strongSelf.topic)")
+            strongSelf.state = ChannelState.closed
+            strongSelf.socket.remove(strongSelf)
         }
         
         /// Perfom when the Channel errors
-        self.onError { (_) in
-            guard self.isLeaving || !self.isClosed else { return }
-            self.socket.logItems("channel", "error \(self.topic)")
-            self.state = ChannelState.errored
-            self.rejoinTimer?.scheduleTimeout()
+        self.onError { [weak self] (_) in
+            guard let strongSelf = self else { return }
+            guard strongSelf.isLeaving || !strongSelf.isClosed else { return }
+            strongSelf.socket.logItems("channel", "error \(strongSelf.topic)")
+            strongSelf.state = ChannelState.errored
+            strongSelf.rejoinTimer?.scheduleTimeout()
         }
         
-        self.joinPush.receive("timeout") { (_) in
-            guard !self.isJoining else { return }
-            self.socket.logItems("channel", "timeout \(self.topic) \(self.joinRef) after \(self.timeout)ms")
+        self.joinPush.receive("timeout") { [weak self] (_) in
+            guard let strongSelf = self else { return }
+            guard !strongSelf.isJoining else { return }
+            strongSelf.socket.logItems("channel", "timeout \(strongSelf.topic) \(strongSelf.joinRef) after \(strongSelf.timeout)ms")
             
-            let leavePush = Push(channel: self, event: ChannelEvent.leave, payload: [:], timeout: self.timeout)
+            let leavePush = Push(channel: strongSelf, event: ChannelEvent.leave, payload: [:], timeout: strongSelf.timeout)
             leavePush.send()
             
-            self.state = ChannelState.errored
-            self.joinPush.reset()
-            self.rejoinTimer?.scheduleTimeout()
+            strongSelf.state = ChannelState.errored
+            strongSelf.joinPush.reset()
+            strongSelf.rejoinTimer?.scheduleTimeout()
         }
         
-        self.on(ChannelEvent.reply) { (message) in
-            let replyEventName = self.replyEventName(message.ref)
+        self.on(ChannelEvent.reply) { [weak self] (message) in
+            guard let strongSelf = self else { return }
+            let replyEventName = strongSelf.replyEventName(message.ref)
             let replyMessage = Message(ref: message.ref, topic: message.topic, event: replyEventName, payload: message.payload)
-            self.trigger(replyMessage)
+            strongSelf.trigger(replyMessage)
         }
     }
-    
+
+    deinit {
+        rejoinTimer.reset()
+    }
     
     /// Overridable message hook. Receives all events for specialized message
     /// handling before dispatching to the channel callbacks.

--- a/Sources/Push.swift
+++ b/Sources/Push.swift
@@ -126,7 +126,7 @@ public class Push {
         self.startTimeout()
         self.sent = true
         
-        channel.socket.push(
+        channel.socket?.push(
             topic: channel.topic,
             event: self.event,
             payload: self.payload,
@@ -173,9 +173,9 @@ public class Push {
     /// time, in milliseconds, is reached.
     func startTimeout() {
         if let _ = self.timeoutTimer { self.cancelTimeout() }
-        guard let channel = channel else { return }
+        guard let channel = channel, let socket = channel.socket else { return }
         
-        let ref = channel.socket.makeRef()
+        let ref = socket.makeRef()
         self.ref = ref
         let refEvent = channel.replyEventName(ref)
         self.refEvent = refEvent

--- a/Sources/Push.swift
+++ b/Sources/Push.swift
@@ -11,7 +11,7 @@ import Foundation
 public class Push {
     
     /// The channel
-    let channel: Channel
+    weak var channel: Channel?
     
     /// The event, for example ChannelEvent.join
     let event: String
@@ -121,16 +121,17 @@ public class Push {
     // MARK: - Library Private
     //----------------------------------------------------------------------
     func send() {
+        guard let channel = channel else { return }
         if hasReceived(status: "timeout") { return }
         self.startTimeout()
         self.sent = true
         
-        self.channel.socket.push(
-            topic: self.channel.topic,
+        channel.socket.push(
+            topic: channel.topic,
             event: self.event,
             payload: self.payload,
             ref: self.ref,
-            joinRef: self.channel.joinRef
+            joinRef: channel.joinRef
         )
     }
     
@@ -159,7 +160,7 @@ public class Push {
     /// Reverses the result on channel.on(ChannelEvent, callback) that spawned the Push
     func cancelRefEvent() {
         guard let refEvent = self.refEvent else { return }
-        self.channel.off(refEvent)
+        self.channel?.off(refEvent)
     }
     
     /// Cancel any ongoing Timeout Timer
@@ -172,22 +173,25 @@ public class Push {
     /// time, in milliseconds, is reached.
     func startTimeout() {
         if let _ = self.timeoutTimer { self.cancelTimeout() }
+        guard let channel = channel else { return }
         
-        let ref = self.channel.socket.makeRef()
+        let ref = channel.socket.makeRef()
         self.ref = ref
-        let refEvent = self.channel.replyEventName(ref)
+        let refEvent = channel.replyEventName(ref)
         self.refEvent = refEvent
         
         /// If a response is received  before the Timer triggers, cancel timer
         /// and match the recevied event to it's corresponding hook
-        self.channel.on(refEvent) { (message) in
-            self.cancelRefEvent()
-            self.cancelTimeout()
-            self.receivedMessage = message
+        channel.on(refEvent) { [weak self] (message) in
+            guard let strongSelf = self else { return }
+
+            strongSelf.cancelRefEvent()
+            strongSelf.cancelTimeout()
+            strongSelf.receivedMessage = message
             
             /// Check if there is event a status available
             guard let status = message.status else { return }
-            self.matchReceive(status, message: message)
+            strongSelf.matchReceive(status, message: message)
         }
         
         /// Start the Timeout timer.
@@ -232,6 +236,6 @@ public class Push {
         mutPayload["status"] = status
         
         let message = Message(ref: refEvent, payload: mutPayload)
-        self.channel.trigger(message)
+        self.channel?.trigger(message)
     }
 }

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -118,9 +118,11 @@ public class Socket {
     init(connection: WebSocket) {
         self.connection = connection
         self._endpoint = connection.currentURL
-        self.reconnectTimer = PhxTimer(callback: {
-            self.disconnect({ self.connect() })
-        }, timerCalc: reconnectAfterMs)
+        self.reconnectTimer = PhxTimer(callback: { [weak self] in
+            self?.disconnect({ self?.connect() })
+        }, timerCalc: { [weak self] tryCount in
+            return self?.reconnectAfterMs(tryCount) ?? 10000
+        })
     }
     
     /// Initializes the Socket
@@ -151,7 +153,9 @@ public class Socket {
         self.init(url: parsedUrl, params: params)
     }
     
-    
+    deinit {
+        reconnectTimer.reset()
+    }
     
     //----------------------------------------------------------------------
     // MARK: - Public

--- a/Tests/ChannelSpec.swift
+++ b/Tests/ChannelSpec.swift
@@ -53,10 +53,15 @@ class ChannelSpec: QuickSpec {
             
             it("sets up the joinPush", closure: {
                 let joinPush = channel.joinPush
-                expect(joinPush?.channel.topic).to(equal(channel.topic))
+                expect(joinPush?.channel?.topic).to(equal(channel.topic))
                 expect(joinPush?.payload["one"] as? Int).to(equal(2))
                 expect(joinPush?.event).to(equal(ChannelEvent.join))
                 expect(joinPush?.timeout).to(equal(PHOENIX_DEFAULT_TIMEOUT))
+            })
+
+            it("should not introduce any retain cycles", closure: {
+                weak var channel = Channel(topic: "topic", params: ["one": 2], socket: mockSocket)
+                expect(channel).to(beNil())
             })
         }
         

--- a/Tests/SocketSpec.swift
+++ b/Tests/SocketSpec.swift
@@ -84,6 +84,11 @@ class SocketSpec: QuickSpec {
                     .endpointUrl.absoluteString)
                     .to(equal("ws://localhost:4000/socket/websocket?token=abc%20123&user_id=1"))
             })
+
+            it("should not introduce any retain cycles", closure: {
+                weak var socket = Socket(url: "http://localhost:4000/socket/websocket")
+                expect(socket).to(beNil())
+            })
         }
         
         


### PR DESCRIPTION
Fixes #109

Fixes strong reference cycles by using `weak`, following these "rules":

- `Socket` owns `Channel`s (with `Channel` having a weak reference back to `Socket`)
- `Channel` owns `Push`es  (with `Push` having a weak reference back to `Channel`)
- `Socket` / `Channel` own `PhxTimer`s, used `weak` in callback blocks to break the strong reference cycle
    - In addition, `Socket` / `Channel` now also `reset()` their timers in `deinit`
