### PR TITLE
Fixes leak and Socket.disconnect() not calling onClose

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -183,7 +183,8 @@ public class Socket {
         connection.delegate = nil
         connection.disconnect()
 
-        onConnectionClosed()
+        self.heartbeatTimer?.invalidate()
+        self.onCloseCallbacks.forEach( { $0() } )
         
         callback?()
     }

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -182,6 +182,8 @@ public class Socket {
     public func disconnect(_ callback: (() -> Void)? = nil) {
         connection.delegate = nil
         connection.disconnect()
+
+        onConnectionClosed()
         
         callback?()
     }

--- a/Tests/SocketSpec.swift
+++ b/Tests/SocketSpec.swift
@@ -99,6 +99,18 @@ class SocketSpec: QuickSpec {
                 expect(fakeConnection.delegate).to(beNil())
                 expect(callbackCalled).to(beTrue())
             })
+
+            it("should fire onClose", closure: {
+                var onCloseCallsCount = 0
+                var onCloseCalled: Bool { return onCloseCallsCount > 0 }
+
+                socket.onClose(callback: {
+                    onCloseCallsCount += 1
+                })
+                socket.disconnect()
+
+                expect(onCloseCalled).to(beTrue())
+            })
         }
         
         describe(".connect()") {


### PR DESCRIPTION
Fixes #110, specifically:

- `Socket` may "leak" even after disconnected, because [a `Timer` holds a strong reference to it](https://github.com/davidstump/SwiftPhoenixClient/blob/b2e7b69607d5fd6f8a7ec05f063f78012ba9551a/Sources/Socket.swift#L415-L418), even after `disconnect()` is called
- I don't believe [`onClose` was being fired](https://github.com/davidstump/SwiftPhoenixClient/blob/b2e7b69607d5fd6f8a7ec05f063f78012ba9551a/Sources/Socket.swift#L179) because the `connection.delegate` gets set to `nil`

I'm not 100% sure calling `onConnectionClosed()` is the right option here though, as there may be unintended side effects (like the autoreconnect timer starting)  @davidstump thoughts?