### PR TITLE
pin starscream to 3.0.6 for swift 4.2 builds

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" >= 3.0
+github "daltoniam/Starscream" = 3.0.6


### PR DESCRIPTION
closes #131 

Setting Starscream version to 3.0.6 in Cartfile to maintain swift 4.2 compatibility until swift 5 upgrade