### PR TITLE
Add tvOS target

### DIFF
--- a/Sources/client/Channel.swift
+++ b/Sources/client/Channel.swift
@@ -54,6 +54,9 @@ struct Binding {
 ///         .receive("error") { payload in print("Failed ot join", payload) }
 ///         .receive("timeout") { payload in print("Networking issue...", payload) }
 ///
+
+import Foundation
+
 public class Channel {
   
   /// The topic of the Channel. e.g. "rooms:friends"

--- a/Sources/client/TimeoutTimer.swift
+++ b/Sources/client/TimeoutTimer.swift
@@ -39,6 +39,9 @@
 ///     reconnectTimer.scheduleTimeout() // fires after 5000ms
 ///     reconnectTimer.reset()
 ///     reconnectTimer.scheduleTimeout() // fires after 1000ms
+
+import Foundation
+
 class TimeoutTimer {
   
   /// Callback to be informed when the underlying Timer fires

--- a/Sources/client/Utilities/Defaults.swift
+++ b/Sources/client/Utilities/Defaults.swift
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import Foundation
 
 /// A collection of default values and behaviors used accross the Client
 public class Defaults {

--- a/SwiftPhoenixClient.xcodeproj/project.pbxproj
+++ b/SwiftPhoenixClient.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		0B8517E31DAC11C80093A015 /* Socket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8517E21DAC11C80093A015 /* Socket.swift */; };
 		0B8517E51DAC12F40093A015 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8517E41DAC12F40093A015 /* Channel.swift */; };
 		0BFAE4F51DA84F59000B3CD3 /* SwiftPhoenixClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BFAE4E71DA84F59000B3CD3 /* SwiftPhoenixClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		12046066202E9AAD00036A92 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 12046065202E9AAD00036A92 /* Starscream.framework */; };
 		120B42C722233A0D00FE483D /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120B42C622233A0D00FE483D /* Defaults.swift */; };
 		120B42C9222341CF00FE483D /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120B42C8222341CF00FE483D /* TestHelpers.swift */; };
 		120B42CB2223481600FE483D /* MockableClass.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120B42CA2223481500FE483D /* MockableClass.generated.swift */; };
@@ -29,6 +28,17 @@
 		63CD642E1DB11E8400C406A6 /* Presence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CD642D1DB11E8400C406A6 /* Presence.swift */; };
 		63CD64321DB1272400C406A6 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CD64311DB1272400C406A6 /* Message.swift */; };
 		B48458A82164E3D300466E32 /* PresenceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B48458A62164E28500466E32 /* PresenceSpec.swift */; };
+		E330971E22B9E6A300BCF98A /* SwiftPhoenixClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BFAE4E71DA84F59000B3CD3 /* SwiftPhoenixClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E38FACD222B9EA4500D80A7D /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38FACD022B9EA4500D80A7D /* Starscream.framework */; };
+		E38FACD422B9EA4A00D80A7D /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38FACD122B9EA4500D80A7D /* Starscream.framework */; };
+		E38FACD522B9EAE500D80A7D /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120B42C622233A0D00FE483D /* Defaults.swift */; };
+		E38FACD622B9EAEF00D80A7D /* Delegated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12BCCB442210CED9001A55E1 /* Delegated.swift */; };
+		E38FACD722B9EAF500D80A7D /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8517E41DAC12F40093A015 /* Channel.swift */; };
+		E38FACD822B9EAF500D80A7D /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CD64311DB1272400C406A6 /* Message.swift */; };
+		E38FACD922B9EAF500D80A7D /* Presence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CD642D1DB11E8400C406A6 /* Presence.swift */; };
+		E38FACDA22B9EAF500D80A7D /* Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1220C3F8202FA808001664A2 /* Push.swift */; };
+		E38FACDB22B9EAF500D80A7D /* Socket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8517E21DAC11C80093A015 /* Socket.swift */; };
+		E38FACDC22B9EAF500D80A7D /* TimeoutTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124A083621F1575B003D1400 /* TimeoutTimer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,8 +59,6 @@
 		0BFAE4E81DA84F59000B3CD3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0BFAE4ED1DA84F59000B3CD3 /* SwiftPhoenixClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftPhoenixClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BFAE4F41DA84F59000B3CD3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		0BFAE5081DA853B5000B3CD3 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = "Vendor/Starscream/build/Debug-iphoneos/Starscream.framework"; sourceTree = "<group>"; };
-		12046065202E9AAD00036A92 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
 		120B42C622233A0D00FE483D /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		120B42C8222341CF00FE483D /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		120B42CA2223481500FE483D /* MockableClass.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockableClass.generated.swift; sourceTree = "<group>"; };
@@ -68,6 +76,11 @@
 		63CD642D1DB11E8400C406A6 /* Presence.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Presence.swift; sourceTree = "<group>"; tabWidth = 2; };
 		63CD64311DB1272400C406A6 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		B48458A62164E28500466E32 /* PresenceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresenceSpec.swift; sourceTree = "<group>"; };
+		E330972322B9E6A300BCF98A /* SwiftPhoenixClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftPhoenixClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E38FACD022B9EA4500D80A7D /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
+		E38FACD122B9EA4500D80A7D /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/tvOS/Starscream.framework; sourceTree = "<group>"; };
+		E38FACF622B9EE4400D80A7D /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
+		E38FACF722B9EE4400D80A7D /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,7 +88,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				12046066202E9AAD00036A92 /* Starscream.framework in Frameworks */,
+				E38FACD222B9EA4500D80A7D /* Starscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,6 +99,14 @@
 				12252F58202EA52C000BA6A2 /* SwiftPhoenixClient.framework in Frameworks */,
 				12252F56202EA467000BA6A2 /* Quick.framework in Frameworks */,
 				12252F57202EA467000BA6A2 /* Nimble.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E330971B22B9E6A300BCF98A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E38FACD422B9EA4A00D80A7D /* Starscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,6 +128,7 @@
 			children = (
 				0BFAE4E41DA84F59000B3CD3 /* SwiftPhoenixClient.framework */,
 				0BFAE4ED1DA84F59000B3CD3 /* SwiftPhoenixClientTests.xctest */,
+				E330972322B9E6A300BCF98A /* SwiftPhoenixClient.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -134,10 +156,12 @@
 		0BFAE5071DA853B5000B3CD3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E38FACF622B9EE4400D80A7D /* Nimble.framework */,
+				E38FACF722B9EE4400D80A7D /* Quick.framework */,
+				E38FACD122B9EA4500D80A7D /* Starscream.framework */,
+				E38FACD022B9EA4500D80A7D /* Starscream.framework */,
 				12252F55202EA467000BA6A2 /* Nimble.framework */,
 				12252F54202EA467000BA6A2 /* Quick.framework */,
-				12046065202E9AAD00036A92 /* Starscream.framework */,
-				0BFAE5081DA853B5000B3CD3 /* Starscream.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -216,6 +240,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E330971D22B9E6A300BCF98A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E330971E22B9E6A300BCF98A /* SwiftPhoenixClient.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -255,6 +287,24 @@
 			productReference = 0BFAE4ED1DA84F59000B3CD3 /* SwiftPhoenixClientTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		E330971122B9E6A300BCF98A /* SwiftPhoenixClient-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E330972022B9E6A300BCF98A /* Build configuration list for PBXNativeTarget "SwiftPhoenixClient-tvOS" */;
+			buildPhases = (
+				E330971222B9E6A300BCF98A /* Sources */,
+				E330971B22B9E6A300BCF98A /* Frameworks */,
+				E330971D22B9E6A300BCF98A /* Headers */,
+				E330971F22B9E6A300BCF98A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SwiftPhoenixClient-tvOS";
+			productName = SwiftPhoenixClient;
+			productReference = E330972322B9E6A300BCF98A /* SwiftPhoenixClient.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -291,6 +341,7 @@
 			targets = (
 				0BFAE4E31DA84F59000B3CD3 /* SwiftPhoenixClient */,
 				0BFAE4EC1DA84F59000B3CD3 /* SwiftPhoenixClientTests */,
+				E330971122B9E6A300BCF98A /* SwiftPhoenixClient-tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -304,6 +355,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0BFAE4EB1DA84F59000B3CD3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E330971F22B9E6A300BCF98A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -341,6 +399,21 @@
 				12EAFF29202F656300685575 /* SocketSpec.swift in Sources */,
 				B48458A82164E3D300466E32 /* PresenceSpec.swift in Sources */,
 				120B42C9222341CF00FE483D /* TestHelpers.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E330971222B9E6A300BCF98A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E38FACD522B9EAE500D80A7D /* Defaults.swift in Sources */,
+				E38FACDB22B9EAF500D80A7D /* Socket.swift in Sources */,
+				E38FACDA22B9EAF500D80A7D /* Push.swift in Sources */,
+				E38FACD822B9EAF500D80A7D /* Message.swift in Sources */,
+				E38FACD922B9EAF500D80A7D /* Presence.swift in Sources */,
+				E38FACDC22B9EAF500D80A7D /* TimeoutTimer.swift in Sources */,
+				E38FACD722B9EAF500D80A7D /* Channel.swift in Sources */,
+				E38FACD622B9EAEF00D80A7D /* Delegated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -488,6 +561,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
 				);
 				INFOPLIST_FILE = "Sources/client/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -514,6 +588,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
 				);
 				INFOPLIST_FILE = "Sources/client/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -559,6 +634,63 @@
 			};
 			name = Release;
 		};
+		E330972122B9E6A300BCF98A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "Sources/client/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.phoenixframework.SwiftPhoenixClient;
+				PRODUCT_MODULE_NAME = SwiftPhoenixClient;
+				PRODUCT_NAME = SwiftPhoenixClient;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.2;
+			};
+			name = Debug;
+		};
+		E330972222B9E6A300BCF98A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "Sources/client/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.phoenixframework.SwiftPhoenixClient;
+				PRODUCT_MODULE_NAME = SwiftPhoenixClient;
+				PRODUCT_NAME = SwiftPhoenixClient;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -585,6 +717,15 @@
 			buildConfigurations = (
 				0BFAE4FC1DA84F59000B3CD3 /* Debug */,
 				0BFAE4FD1DA84F59000B3CD3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E330972022B9E6A300BCF98A /* Build configuration list for PBXNativeTarget "SwiftPhoenixClient-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E330972122B9E6A300BCF98A /* Debug */,
+				E330972222B9E6A300BCF98A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SwiftPhoenixClient.xcodeproj/xcshareddata/xcschemes/SwiftPhoenixClient-tvOS.xcscheme
+++ b/SwiftPhoenixClient.xcodeproj/xcshareddata/xcschemes/SwiftPhoenixClient-tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E330971122B9E6A300BCF98A"
+               BuildableName = "SwiftPhoenixClient.framework"
+               BlueprintName = "SwiftPhoenixClient-tvOS"
+               ReferencedContainer = "container:SwiftPhoenixClient.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E38FACDD22B9ECF200D80A7D"
+               BuildableName = "SwiftPhoenixClientTests-tvOS.xctest"
+               BlueprintName = "SwiftPhoenixClientTests-tvOS"
+               ReferencedContainer = "container:SwiftPhoenixClient.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E330971122B9E6A300BCF98A"
+            BuildableName = "SwiftPhoenixClient.framework"
+            BlueprintName = "SwiftPhoenixClient-tvOS"
+            ReferencedContainer = "container:SwiftPhoenixClient.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E330971122B9E6A300BCF98A"
+            BuildableName = "SwiftPhoenixClient.framework"
+            BlueprintName = "SwiftPhoenixClient-tvOS"
+            ReferencedContainer = "container:SwiftPhoenixClient.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E330971122B9E6A300BCF98A"
+            BuildableName = "SwiftPhoenixClient.framework"
+            BlueprintName = "SwiftPhoenixClient-tvOS"
+            ReferencedContainer = "container:SwiftPhoenixClient.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Have only added the tvOS target and not the tests, as `throws if attempting to join multiple times` runs into a `fatalError()`, which is an `EXC_BAD_INSTRUCTION` which doesn't seem to be caught on tvOS (sorry I'm not 100% across why this).

I went back further in the history (0.6.x) to see how it was handled previously and noticed that there weren't any tests for tvOS either so not sure if you came across this problem previously too?  