### PR TITLE
Adding Rx wrapper to channel.on(event:)

### DIFF
--- a/Sources/RxSwiftPhoenix/Channel+Rx.swift
+++ b/Sources/RxSwiftPhoenix/Channel+Rx.swift
@@ -1,0 +1,46 @@
+//
+//  Channel+Rx.swift
+//  RxSwiftPhoenix
+//
+//  Created by Daniel Rees on 10/16/19.
+//
+
+import Foundation
+import RxSwift
+import SwiftPhoenix
+
+extension Channel: ReactiveCompatible { }
+
+public extension Reactive where Base: Channel {
+  
+  /// Subscribes on channel events. Disposing of the Subscription will remove
+  /// the event callback from the `Channel`.
+  ///
+  /// There is no error handling, meaning `onError(_)` will never be emitted.
+  /// You should inspect the `Message` payload to perform any error handling.
+  ///
+  /// Example:
+  ///
+  ///     let channel = socket.channel("topic")
+  ///     let disposeBag = DisposeBag()
+  ///
+  /// // Subscribe to `Message`s for the "event" event
+  ///     channel.rx.on("event").subscribe(onNext: { (message) in
+  ///       print("do stuff")
+  ///     }).addDisposableTo(disposeBag)
+  ///
+  /// // Clean up the "event" event subscription
+  ///     disposeBag.dispose()
+  ///
+  /// - parameter event: Event to susbcribe to
+  /// - return: Observbale that will emit Messages for `event`
+  func on(_ event: String) -> Observable<Message> {
+    return Observable.create { [weak base] observer in
+      let refId = base?.on(event, callback: { observer.onNext($0) })
+      return Disposables.create {
+        base?.off(event, ref: refId)
+      }
+    }
+  }
+  
+}

--- a/SwiftPhoenix.xcodeproj/project.pbxproj
+++ b/SwiftPhoenix.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		1288EE17235807CE00338679 /* TimeoutTimerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1288EE12235807CE00338679 /* TimeoutTimerSpec.swift */; };
 		1288EE18235807CE00338679 /* PresenceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1288EE13235807CE00338679 /* PresenceSpec.swift */; };
 		1288EE1A235807CE00338679 /* ChannelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1288EE15235807CE00338679 /* ChannelSpec.swift */; };
+		1288EE1C2358094200338679 /* Channel+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1288EE1B2358094200338679 /* Channel+Rx.swift */; };
+		1288EE1F23580BFC00338679 /* ChannelRxSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1288EE1D23580BD000338679 /* ChannelRxSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +85,8 @@
 		1288EE12235807CE00338679 /* TimeoutTimerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeoutTimerSpec.swift; sourceTree = "<group>"; };
 		1288EE13235807CE00338679 /* PresenceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresenceSpec.swift; sourceTree = "<group>"; };
 		1288EE15235807CE00338679 /* ChannelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelSpec.swift; sourceTree = "<group>"; };
+		1288EE1B2358094200338679 /* Channel+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Channel+Rx.swift"; sourceTree = "<group>"; };
+		1288EE1D23580BD000338679 /* ChannelRxSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRxSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -193,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				1232241A2357F49C00BCA87A /* Phoenix+Rx.swift */,
+				1288EE1B2358094200338679 /* Channel+Rx.swift */,
 			);
 			path = RxSwiftPhoenix;
 			sourceTree = "<group>";
@@ -213,6 +218,7 @@
 			isa = PBXGroup;
 			children = (
 				123224262357FC8E00BCA87A /* Phoenix+RxSpec.swift */,
+				1288EE1D23580BD000338679 /* ChannelRxSpec.swift */,
 			);
 			path = RxSwiftPhoenix;
 			sourceTree = "<group>";
@@ -442,6 +448,7 @@
 				1288EE062358061700338679 /* FakeTimerQueueSpec.swift in Sources */,
 				1288EE18235807CE00338679 /* PresenceSpec.swift in Sources */,
 				1288EE16235807CE00338679 /* SocketSpec.swift in Sources */,
+				1288EE1F23580BFC00338679 /* ChannelRxSpec.swift in Sources */,
 				123224272357FC8E00BCA87A /* Phoenix+RxSpec.swift in Sources */,
 				1288EE0E2358072500338679 /* MockableWebSocketClient.generated.swift in Sources */,
 				1288EE17235807CE00338679 /* TimeoutTimerSpec.swift in Sources */,
@@ -455,6 +462,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1232241B2357F49C00BCA87A /* Phoenix+Rx.swift in Sources */,
+				1288EE1C2358094200338679 /* Channel+Rx.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/RxSwiftPhoenix/ChannelRxSpec.swift
+++ b/Tests/RxSwiftPhoenix/ChannelRxSpec.swift
@@ -1,0 +1,124 @@
+//
+//  ChannelRxSpec.swift
+//  RxSwiftPhoenix
+//
+//  Created by Daniel Rees on 10/16/19.
+//
+
+import Quick
+import Nimble
+import RxSwift
+@testable import SwiftPhoenix
+import RxSwiftPhoenix
+
+final class ChannelRxSpec: QuickSpec {
+  
+  override func spec() {
+    
+    // Mocks
+    var mockClient: WebSocketClientMock!
+    var mockSocket: SocketMock!
+    
+    // Constants
+    let kDefaultRef = "1"
+    let kDefaultTimeout: TimeInterval = 10.0
+    
+    // UUT
+    var channel: Channel!
+    
+    beforeEach {
+      mockClient = WebSocketClientMock()
+      
+      mockSocket = SocketMock("/socket")
+      mockSocket.connection = mockClient
+      mockSocket.timeout = kDefaultTimeout
+      mockSocket.makeRefReturnValue = kDefaultRef
+      mockSocket.reconnectAfter = { tries -> TimeInterval in
+        return tries > 3 ? 10 : [1, 2, 5, 10][tries - 1]
+      }
+      
+      channel = Channel(topic: "topic", params: ["one": "two"], socket: mockSocket)
+      mockSocket.channelParamsReturnValue = channel
+    }
+    
+    
+    describe("rx.on") {
+      
+      beforeEach {
+        mockSocket.makeRefClosure = nil
+        mockSocket.makeRefReturnValue = kDefaultRef
+      }
+      
+      it("sets up callback for event", closure: {
+        var onCallCount = 0
+        
+        channel.trigger(event: "event", ref: kDefaultRef)
+        expect(onCallCount).to(equal(0))
+        
+        let _ = channel.rx.on("event")
+          .subscribe(onNext: { (message) in
+            onCallCount += 1
+          })
+        
+        channel.trigger(event: "event", ref: kDefaultRef)
+        expect(onCallCount).to(equal(1))
+      })
+      
+      it("other event callbacks are ignored", closure: {
+        var onCallCount = 0
+        var ignoredOnCallCount = 0
+        
+        channel.trigger(event: "event", ref: kDefaultRef)
+        expect(ignoredOnCallCount).to(equal(0))
+        
+        let _ = channel.rx.on("event")
+        .subscribe(onNext: { (message) in
+          onCallCount += 1
+        })
+        
+        let _ = channel.rx.on("ignored_event")
+        .subscribe(onNext: { (message) in
+          ignoredOnCallCount += 1
+        })
+        
+        channel.trigger(event: "event", ref: kDefaultRef)
+        channel.trigger(event: "event", ref: kDefaultRef)
+        channel.trigger(event: "ignored_event", ref: kDefaultRef)
+        expect(onCallCount).to(equal(2))
+        expect(ignoredOnCallCount).to(equal(1))
+      })
+      
+      it("does not emit events to disposed subscriptions") {
+        var callCount1 = 0
+        var callCount2 = 0
+        
+        let sub1 = channel.rx.on("event")
+          .subscribe(onNext: { (message) in
+            callCount1 += 1
+          })
+        
+        let sub2 = channel.rx.on("event")
+          .subscribe(onNext: { (message) in
+            callCount2 += 1
+          })
+        
+        // Trigger event to both
+        channel.trigger(event: "event", ref: kDefaultRef)
+        
+        // Dispose of sub1
+        sub1.dispose()
+        
+        // Trigger event only to sub2
+        channel.trigger(event: "event", ref: kDefaultRef)
+        
+        sub2.dispose()
+        
+        // Trigger event neithers
+        channel.trigger(event: "event", ref: kDefaultRef)
+        
+        expect(callCount1).to(equal(1))
+        expect(callCount2).to(equal(2))
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Added Rx extension to convert `channel.on(event:, callback:)` to an Rx Observable
* Added spec to extension to verify behavior and proper disposal of event listener