### PR TITLE
Made init public and added test for setting callBackqueue on transport

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -173,7 +173,7 @@ public class Socket {
   }
   
   
-  init(endPoint: String,
+  public init(endPoint: String,
        transport: @escaping ((URL) -> WebSocketClient),
        paramsClosure: PayloadClosure? = nil) {
     self.transport = transport

--- a/Tests/client/SocketSpec.swift
+++ b/Tests/client/SocketSpec.swift
@@ -59,6 +59,21 @@ class SocketSpec: QuickSpec {
         expect(socket.reconnectAfter(2)).to(equal(10))
       })
       
+      it("sets queue for underlying transport", closure: {
+        let socket = Socket(endPoint: "wss://localhost:4000/socket", transport: { (url) -> WebSocketClient in
+            let webSocket = WebSocket(url: url)
+            webSocket.callbackQueue = DispatchQueue(label: "test_queue")
+            return webSocket
+        })
+        socket.timeout = 40000
+        socket.heartbeatInterval = 60000
+        socket.logger = { _ in }
+        socket.reconnectAfter = { _ in return 10 }
+        socket.connect()
+        expect(socket.connection).to(beAKindOf(WebSocket.self))
+        expect((socket.connection as! WebSocket).callbackQueue.label).to(equal("test_queue"))
+      })
+      
       it("should construct a valid URL", closure: {
         
         // Test different schemes


### PR DESCRIPTION
Based off #159 

I needed to be able to set the callback queue on the transport manually so made the init public.

Not 100% on the test as you need to manually call connect to populate the connection so you may want that moved elsewhere.