### PR TITLE
Made init public and added test for setting callBackqueue on transport

### DIFF
--- a/Sources/HeartbeatTimer.swift
+++ b/Sources/HeartbeatTimer.swift
@@ -20,9 +20,10 @@
 
 import Foundation
 
-class HeartbeatTimer {
+class HeartbeatTimer: Equatable {
     let timeInterval: TimeInterval
     let dispatchQueue: DispatchQueue
+    let id: String = UUID().uuidString
     init(timeInterval: TimeInterval, dispatchQueue: DispatchQueue) {
         self.timeInterval = timeInterval
         self.dispatchQueue = dispatchQueue
@@ -36,6 +37,10 @@ class HeartbeatTimer {
         })
         return t
     }()
+    
+    var isValid: Bool {
+        return state == .resumed
+    }
     
     private var eventHandler: (() -> Void)?
     
@@ -52,6 +57,8 @@ class HeartbeatTimer {
     }
     
     func stopTimer() {
+        timer.setEventHandler {}
+        eventHandler = nil
         suspend()
     }
     
@@ -71,6 +78,10 @@ class HeartbeatTimer {
         timer.suspend()
     }
     
+    func fire() {
+        eventHandler?()
+    }
+    
     deinit {
         timer.setEventHandler {}
         timer.cancel()
@@ -80,5 +91,9 @@ class HeartbeatTimer {
          */
         resume()
         eventHandler = nil
+    }
+    
+    static func == (lhs: HeartbeatTimer, rhs: HeartbeatTimer) -> Bool {
+        return lhs.id == rhs.id
     }
 }

--- a/Sources/HeartbeatTimer.swift
+++ b/Sources/HeartbeatTimer.swift
@@ -1,0 +1,84 @@
+// Copyright (c) 2019 David Stump <david@davidstump.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+class HeartbeatTimer {
+    let timeInterval: TimeInterval
+    let dispatchQueue: DispatchQueue
+    init(timeInterval: TimeInterval, dispatchQueue: DispatchQueue) {
+        self.timeInterval = timeInterval
+        self.dispatchQueue = dispatchQueue
+    }
+    
+    private lazy var timer: DispatchSourceTimer = {
+        let t = DispatchSource.makeTimerSource(flags: [], queue: self.dispatchQueue)
+        t.schedule(deadline: .now() + self.timeInterval, repeating: self.timeInterval)
+        t.setEventHandler(handler: { [weak self] in
+            self?.eventHandler?()
+        })
+        return t
+    }()
+    
+    private var eventHandler: (() -> Void)?
+    
+    private enum State {
+        case suspended
+        case resumed
+    }
+    private var state: State = .suspended
+    
+    
+    func startTimerWithEvent(eventHandler: (() -> Void)?) {
+        self.eventHandler = eventHandler
+        resume()
+    }
+    
+    func stopTimer() {
+        suspend()
+    }
+    
+    private func resume() {
+        if state == .resumed {
+            return
+        }
+        state = .resumed
+        timer.resume()
+    }
+    
+    private func suspend() {
+        if state == .suspended {
+            return
+        }
+        state = .suspended
+        timer.suspend()
+    }
+    
+    deinit {
+        timer.setEventHandler {}
+        timer.cancel()
+        /*
+         If the timer is suspended, calling cancel without resuming
+         triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
+         */
+        resume()
+        eventHandler = nil
+    }
+}

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -139,8 +139,11 @@ public class Socket {
   /// Ref counter for messages
   var ref: UInt64 = UInt64.min // 0 (max: 18,446,744,073,709,551,615)
   
+  ///Queue to run heartbeat timer on
+  var heartbeatQueue: DispatchQueue = DispatchQueue(label: "com.phoenix.socket.heartbeat")
+    
   /// Timer that triggers sending new Heartbeat messages
-  var heartbeatTimer: Timer?
+  var heartbeatTimer: HeartbeatTimer?
   
   /// Ref counter for the last heartbeat that was sent
   var pendingHeartbeatRef: String?
@@ -263,7 +266,7 @@ public class Socket {
     self.connection = nil
     
     // The socket connection has been torndown, heartbeats are not needed
-    self.heartbeatTimer?.invalidate()
+    self.heartbeatTimer?.stopTimer()
     self.heartbeatTimer = nil
     
     // Since the connection's delegate was nil'd out, inform all state
@@ -549,7 +552,7 @@ public class Socket {
     self.triggerChannelError()
     
     // Prevent the heartbeat from triggering if the
-    self.heartbeatTimer?.invalidate()
+    self.heartbeatTimer?.stopTimer()
     self.heartbeatTimer = nil
     
     // Only attempt to reconnect if the socket did not close normally
@@ -647,25 +650,17 @@ public class Socket {
   internal func resetHeartbeat() {
     // Clear anything related to the heartbeat
     self.pendingHeartbeatRef = nil
-    self.heartbeatTimer?.invalidate()
+    self.heartbeatTimer?.stopTimer()
     self.heartbeatTimer = nil
     
     // Do not start up the heartbeat timer if skipHeartbeat is true
     guard !skipHeartbeat else { return }
     
-    // Start the timer based on the correct iOS version
-    if #available(iOS 10.0, *) {
-      self.heartbeatTimer
-        = Timer.scheduledTimer(withTimeInterval: heartbeatInterval,
-                               repeats: true) { _ in self.sendHeartbeat() }
-    } else {
-      self.heartbeatTimer
-        = Timer.scheduledTimer(timeInterval: heartbeatInterval,
-                               target: self,
-                               selector: #selector(sendHeartbeat),
-                               userInfo: nil,
-                               repeats: false)
-    }
+    self.heartbeatTimer = HeartbeatTimer(timeInterval: heartbeatInterval, dispatchQueue: heartbeatQueue)
+    
+    self.heartbeatTimer?.startTimerWithEvent(eventHandler: { [weak self] in
+        self?.sendHeartbeat()
+    })
   }
   
   /// Sends a hearbeat payload to the phoenix serverss

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -173,7 +173,7 @@ public class Socket {
   }
   
   
-  init(endPoint: String,
+  public init(endPoint: String,
        transport: @escaping ((URL) -> WebSocketClient),
        paramsClosure: PayloadClosure? = nil) {
     self.transport = transport

--- a/SwiftPhoenixClient.xcodeproj/project.pbxproj
+++ b/SwiftPhoenixClient.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		12F7830C2210D56D00291614 /* MockableWebSocketClient.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F7830A2210D56D00291614 /* MockableWebSocketClient.generated.swift */; };
 		12FAEE47231EB222003EC62B /* SocketSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FAEE46231EB222003EC62B /* SocketSpy.swift */; };
 		12FAEE49231EB4B0003EC62B /* FakeTimerQueueSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FAEE48231EB4B0003EC62B /* FakeTimerQueueSpec.swift */; };
+		4886F286240D2E36006B8376 /* HeartbeatTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4886F285240D2E36006B8376 /* HeartbeatTimer.swift */; };
 		B48458A82164E3D300466E32 /* PresenceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B48458A62164E28500466E32 /* PresenceSpec.swift */; };
 		E38FACD222B9EA4500D80A7D /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38FACD022B9EA4500D80A7D /* Starscream.framework */; };
 		E38FACD422B9EA4A00D80A7D /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38FACD122B9EA4500D80A7D /* Starscream.framework */; };
@@ -75,6 +76,7 @@
 		12F7830A2210D56D00291614 /* MockableWebSocketClient.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockableWebSocketClient.generated.swift; sourceTree = "<group>"; };
 		12FAEE46231EB222003EC62B /* SocketSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketSpy.swift; sourceTree = "<group>"; };
 		12FAEE48231EB4B0003EC62B /* FakeTimerQueueSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTimerQueueSpec.swift; sourceTree = "<group>"; };
+		4886F285240D2E36006B8376 /* HeartbeatTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartbeatTimer.swift; sourceTree = "<group>"; };
 		B48458A62164E28500466E32 /* PresenceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresenceSpec.swift; sourceTree = "<group>"; };
 		E330972322B9E6A300BCF98A /* SwiftPhoenixClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftPhoenixClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E38FACD022B9EA4500D80A7D /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 				1203046E23B112050012FF2D /* Push.swift */,
 				1203046F23B112050012FF2D /* Utilities */,
 				1203047223B112050012FF2D /* TimeoutTimer.swift */,
+				4886F285240D2E36006B8376 /* HeartbeatTimer.swift */,
 				1203047323B112050012FF2D /* Supporting Files */,
 				1203047423B112050012FF2D /* Socket.swift */,
 			);
@@ -373,6 +376,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1203048323B112060012FF2D /* Socket.swift in Sources */,
+				4886F286240D2E36006B8376 /* HeartbeatTimer.swift in Sources */,
 				1203048123B112060012FF2D /* TimeoutTimer.swift in Sources */,
 				1203047523B112050012FF2D /* Presence.swift in Sources */,
 				1203047B23B112060012FF2D /* Push.swift in Sources */,

--- a/Tests/client/SocketSpec.swift
+++ b/Tests/client/SocketSpec.swift
@@ -59,6 +59,21 @@ class SocketSpec: QuickSpec {
         expect(socket.reconnectAfter(2)).to(equal(10))
       })
       
+      it("sets queue for underlying transport", closure: {
+        let socket = Socket(endPoint: "wss://localhost:4000/socket", transport: { (url) -> WebSocketClient in
+            let webSocket = WebSocket(url: url)
+            webSocket.callbackQueue = DispatchQueue(label: "test_queue")
+            return webSocket
+        })
+        socket.timeout = 40000
+        socket.heartbeatInterval = 60000
+        socket.logger = { _ in }
+        socket.reconnectAfter = { _ in return 10 }
+        socket.connect()
+        expect(socket.connection).to(beAKindOf(WebSocket.self))
+        expect((socket.connection as! WebSocket).callbackQueue.label).to(equal("test_queue"))
+      })
+      
       it("should construct a valid URL", closure: {
         
         // Test different schemes

--- a/Tests/client/SocketSpec.swift
+++ b/Tests/client/SocketSpec.swift
@@ -334,9 +334,11 @@ class SocketSpec: QuickSpec {
       
       it("invalidates and releases the heartbeat timer", closure: {
         var timerCalled = 0
-        let timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: false, block: { (_) in
+        let timer = HeartbeatTimer(timeInterval: 10, dispatchQueue: .main)
+          
+        timer.startTimerWithEvent {
           timerCalled += 1
-        })
+        }
         
         socket.heartbeatTimer = timer
         
@@ -668,7 +670,8 @@ class SocketSpec: QuickSpec {
       it("should invalidate an old timer and create a new one", closure: {
         mockWebSocket.isConnected = true
         
-        let timer = Timer.scheduledTimer(withTimeInterval: 1000, repeats: true) { (_) in  }
+        let timer = HeartbeatTimer(timeInterval: 1000, dispatchQueue: .main)
+        timer.startTimerWithEvent { }
         socket.heartbeatTimer = timer
         
         expect(timer.isValid).to(beTrue())

--- a/Tests/mocks/MockableClass.generated.swift
+++ b/Tests/mocks/MockableClass.generated.swift
@@ -631,7 +631,7 @@ class SocketMock: Socket {
     var underlyingRef: (UInt64)!
     var heartbeatTimerSetCount: Int = 0
     var heartbeatTimerDidGetSet: Bool { return heartbeatTimerSetCount > 0 }
-    override var heartbeatTimer: Timer? {
+    override var heartbeatTimer: HeartbeatTimer? {
         didSet { heartbeatTimerSetCount += 1 }
     }
     var pendingHeartbeatRefSetCount: Int = 0


### PR DESCRIPTION
Based off #159 + #160 

I needed to be able to set the callback queue on the transport manually so made the init public.

Not 100% on the test as you need to manually call connect to populate the connection so you may want that moved elsewhere.


- When looking at #159 more the heartbeat timers were not working so the socket server would close the connection. 
This PR also updates the heartbeat timer to use its own thread in order to resolve that issue.