### PR TITLE
Specify platforms in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ import PackageDescription
 
 let package = Package(
   name: "SwiftPhoenixClient",
+  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v2)],
   products: [
     .library(name: "SwiftPhoenixClient", targets: ["SwiftPhoenixClient"])
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ import PackageDescription
 
 let package = Package(
   name: "SwiftPhoenixClient",
-  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v2)],
+  platforms: [.iOS(.v9), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v2)],
   products: [
     .library(name: "SwiftPhoenixClient", targets: ["SwiftPhoenixClient"])
   ],


### PR DESCRIPTION
Fails on macOS with an error that `scheduledTimer(withTimeInterval:repeats:block)` is only available after macOS 10.12. I guessed versions for the other platforms, but they seem sensical to me