### PR TITLE
Make Cartfile consistent with podspec

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" == 3.1.0
+github "daltoniam/Starscream" ~> 3.1.0


### PR DESCRIPTION
Close #172

Make Starsream version consistent in podspec and Cartfile
Also, Cartfile.resolved shows that the version of Starscream is 3.1.1, which is actually compatible with but not limited to 3.1.0