### PR TITLE
Manually upgrading to wss for URLSessionTransport

### DIFF
--- a/Examples/Basic/basic/BasicChatViewController.swift
+++ b/Examples/Basic/basic/BasicChatViewController.swift
@@ -38,6 +38,8 @@ import StarscreamSwiftPhoenixClient
  
  */
 
+let endpoint = "http://localhost:4000/socket/websocket"
+
 class BasicChatViewController: UIViewController {
   
   // MARK: - Child Views
@@ -51,11 +53,13 @@ class BasicChatViewController: UIViewController {
   let username: String = "Basic"
   var topic: String = "rooms:lobby"
   
+  
+  
   // Test the URLSessionTransport
-  let socket = Socket("http://localhost:4000/socket/websocket")
+  let socket = Socket(endpoint)
   
   // Test the StarscreamTransport
-//  let socket = Socket(endPoint: "http://localhost:4000/socket/websocket", transport: { url in return StarscreamTransport(url: url) })
+//  let socket = Socket(endPoint: endpoint, transport: { url in return StarscreamTransport(url: url) })
     
   var lobbyChannel: Channel!
   

--- a/Sources/StarscreamSwiftPhoenixClient/StarscreamTransport.swift
+++ b/Sources/StarscreamSwiftPhoenixClient/StarscreamTransport.swift
@@ -67,8 +67,7 @@ public class StarscreamTransport: NSObject, PhoenixTransport, WebSocketDelegate 
     // Set the trasport state as connecting
     self.readyState = .connecting
     
-    let request = URLRequest(url: url)
-    let socket = WebSocket(request: request)
+    let socket = WebSocket(url: url)
     socket.delegate = self
     socket.connect()
     

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -129,11 +129,11 @@ public enum PhoenixTransportReadyState {
  your own WebSocket library or implementation.
  */
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-public class URLSessionTansport: NSObject, PhoenixTransport, URLSessionWebSocketDelegate {
+public class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketDelegate {
   
   
   /// The URL to connect to
-  private let url: URL
+  internal let url: URL
   
   /// The underling URLsession. Assigned during `connect()`
   private var session: URLSession? = nil
@@ -149,13 +149,22 @@ public class URLSessionTansport: NSObject, PhoenixTransport, URLSessionWebSocket
    
    ```swift
    let url = URL("wss://example.com/socket")
-   let transport: Transport = URLSessionTansport(url: url)
+   let transport: Transport = URLSessionTransport(url: url)
    ```
    
    - parameter url: URL to connect to
    */
   init(url: URL) {
-    self.url = url
+  
+    // URLSession requires that the endpoint be "wss" instead of "https".
+    let endpoint = url.absoluteString
+    let wsEndpoint = endpoint
+      .replacingOccurrences(of: "http://", with: "ws://")
+      .replacingOccurrences(of: "https://", with: "wss://")
+    
+    // Force unwrapping should be safe here since a valid URL came in and we just
+    // replaced the protocol.
+    self.url = URL(string: wsEndpoint)!
     
     super.init()
   }

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -169,7 +169,7 @@ public class Socket: PhoenixTransportDelegate {
   public convenience init(_ endPoint: String,
                           params: Payload? = nil) {
     self.init(endPoint: endPoint,
-              transport: { url in return URLSessionTansport(url: url) },
+              transport: { url in return URLSessionTransport(url: url) },
               paramsClosure: { params })
   }
 
@@ -177,7 +177,7 @@ public class Socket: PhoenixTransportDelegate {
   public convenience init(_ endPoint: String,
                           paramsClosure: PayloadClosure?) {
     self.init(endPoint: endPoint,
-              transport: { url in return URLSessionTansport(url: url) },
+              transport: { url in return URLSessionTransport(url: url) },
               paramsClosure: paramsClosure)
   }
   
@@ -666,14 +666,8 @@ public class Socket: PhoenixTransportDelegate {
 
   /// Builds a fully qualified socket `URL` from `endPoint` and `params`.
   internal static func buildEndpointUrl(endpoint: String, paramsClosure params: PayloadClosure?) -> URL {
-    
-    // Replace 'http' and 'https' with 'ws' or 'wss'
-    let wsEndpoint = endpoint
-      .replacingOccurrences(of: "http://", with: "ws://")
-      .replacingOccurrences(of: "https://", with: "wss://")
-    
     guard
-      let url = URL(string: wsEndpoint),
+      let url = URL(string: endpoint),
       var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
       else { fatalError("Malformed URL: \(endpoint)") }
 

--- a/SwiftPhoenixClient.xcodeproj/project.pbxproj
+++ b/SwiftPhoenixClient.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		631D1882259CE1D7005FAC0E /* SwiftPhoenixClient.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1281439225410D52008615A7 /* SwiftPhoenixClient.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		631D18A6259D26EC005FAC0E /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 631D18A5259D26EC005FAC0E /* Starscream.framework */; };
 		6338892125D1E72000A05817 /* StarscreamTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631D1892259CE2A8005FAC0E /* StarscreamTransport.swift */; };
+		635669C4261631DC0068B665 /* URLSessionTransportSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635669C3261631DC0068B665 /* URLSessionTransportSpec.swift */; };
 		6397FE8A259967E9005E66C3 /* RxSwiftPhoenixClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 128143D425411361008615A7 /* RxSwiftPhoenixClient.framework */; };
 		63F0F58D2592E44800C904FB /* ChatRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0F58C2592E44800C904FB /* ChatRoomViewController.swift */; };
 /* End PBXBuildFile section */
@@ -165,6 +166,7 @@
 		631D1886259CE1D7005FAC0E /* StarscreamSwiftPhoenixClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StarscreamSwiftPhoenixClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		631D1892259CE2A8005FAC0E /* StarscreamTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarscreamTransport.swift; sourceTree = "<group>"; };
 		631D18A5259D26EC005FAC0E /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
+		635669C3261631DC0068B665 /* URLSessionTransportSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTransportSpec.swift; sourceTree = "<group>"; };
 		639D200B2592E81E00A5EEDC /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
 		63F0F58C2592E44800C904FB /* ChatRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -355,6 +357,7 @@
 				12EF620125524B6800A6EE9B /* PresenceSpec.swift */,
 				12EF620225524B6800A6EE9B /* TimeoutTimerSpec.swift */,
 				12EF620325524B6800A6EE9B /* DefaultSerializerSpec.swift */,
+				635669C3261631DC0068B665 /* URLSessionTransportSpec.swift */,
 			);
 			path = SwiftPhoenixClientTests;
 			sourceTree = "<group>";
@@ -688,6 +691,7 @@
 				12EF620825524B6800A6EE9B /* DefaultSerializerSpec.swift in Sources */,
 				12991E11254C456F00BB8650 /* FakeTimerQueue.swift in Sources */,
 				12991E15254C45FC00BB8650 /* FakeTimerQueueSpec.swift in Sources */,
+				635669C4261631DC0068B665 /* URLSessionTransportSpec.swift in Sources */,
 				12EF620725524B6800A6EE9B /* TimeoutTimerSpec.swift in Sources */,
 				12EF620F25524EEF00A6EE9B /* MockableProtocol.generated.swift in Sources */,
 				12991E0F254C454C00BB8650 /* SocketSpy.swift in Sources */,

--- a/Tests/SwiftPhoenixClientTests/SocketSpec.swift
+++ b/Tests/SwiftPhoenixClientTests/SocketSpec.swift
@@ -76,26 +76,12 @@ class SocketSpec: QuickSpec {
       
       it("should construct a valid URL", closure: {
         
-        // Test different schemes
-        expect(Socket("http://localhost:4000/socket/websocket", paramsClosure: nil).endPointUrl.absoluteString)
-          .to(equal("ws://localhost:4000/socket/websocket"))
-        
-        expect(Socket("https://localhost:4000/socket/websocket", paramsClosure: nil).endPointUrl.absoluteString)
-          .to(equal("wss://localhost:4000/socket/websocket"))
-        
-        expect(Socket("ws://localhost:4000/socket/websocket", paramsClosure: nil).endPointUrl.absoluteString)
-          .to(equal("ws://localhost:4000/socket/websocket"))
-        
-        expect(Socket("wss://localhost:4000/socket/websocket", paramsClosure: nil).endPointUrl.absoluteString)
-          .to(equal("wss://localhost:4000/socket/websocket"))
-        
-        
         // test params
-        expect(Socket("ws://localhost:4000/socket/websocket",
+        expect(Socket("http://localhost:4000/socket/websocket",
                       paramsClosure: { ["token": "abc123"] })
           .endPointUrl
           .absoluteString)
-          .to(equal("ws://localhost:4000/socket/websocket?token=abc123"))
+          .to(equal("http://localhost:4000/socket/websocket?token=abc123"))
         
         expect(Socket("ws://localhost:4000/socket/websocket",
                       paramsClosure: { ["token": "abc123", "user_id": 1] })

--- a/Tests/SwiftPhoenixClientTests/URLSessionTransportSpec.swift
+++ b/Tests/SwiftPhoenixClientTests/URLSessionTransportSpec.swift
@@ -1,0 +1,48 @@
+//
+//  URLSessionTransportSpec.swift
+//  SwiftPhoenixClientTests
+//
+//  Created by Daniel Rees on 4/1/21.
+//  Copyright © 2021 SwiftPhoenixClient. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import SwiftPhoenixClient
+
+class URLSessionTransportSpec: QuickSpec {
+  
+  override func spec() {
+    
+    describe("init") {
+      it("replaces http with ws protocols") {
+        if #available(iOS 13, *) {
+          expect(
+            URLSessionTransport(url: URL(string:"http://localhost:4000/socket/websocket")!)
+              .url.absoluteString
+          ).to(equal("ws://localhost:4000/socket/websocket"))
+          
+          expect(
+            URLSessionTransport(url: URL(string:"https://localhost:4000/socket/websocket")!)
+              .url.absoluteString
+          ).to(equal("wss://localhost:4000/socket/websocket"))
+          
+          expect(
+            URLSessionTransport(url: URL(string:"ws://localhost:4000/socket/websocket")!)
+              .url.absoluteString
+          ).to(equal("ws://localhost:4000/socket/websocket"))
+          
+          expect(
+            URLSessionTransport(url: URL(string:"wss://localhost:4000/socket/websocket")!)
+              .url.absoluteString
+          ).to(equal("wss://localhost:4000/socket/websocket"))
+          
+        } else {
+          // Fallback on earlier versions
+          expect("wrong iOS version").to(equal("You must run this test on an iOS 13 device"))
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Starscream automatically handles upgrading an https url
to a wss scheme but does not accept when the url has already
been set to use wss. However URLSession does not do this
so it is expecting the url to already use wss

Fixed by removing the manual upgrade from the URL builder
and only upgrading inside of the URLSessionTransport init