### PR TITLE
Unwrapping response from message payload

### DIFF
--- a/Sources/SwiftPhoenixClient/Message.swift
+++ b/Sources/SwiftPhoenixClient/Message.swift
@@ -35,17 +35,26 @@ public class Message {
   /// Message event
   public let event: String
   
+  /// The raw payload from the Message, including a nested response from
+  /// phx_reply events. It is recommended to use `payload` instead.
+  public let rawPayload: Payload
+  
   /// Message payload
-  public var payload: Payload
+  public var payload: Payload {
+    guard let response = rawPayload["response"] as? Payload
+    else { return rawPayload }
+    return response
+  }
   
   /// Convenience accessor. Equivalent to getting the status as such:
   /// ```swift
   /// message.payload["status"]
   /// ```
   public var status: String? {
-    return payload["status"] as? String
+    return rawPayload["status"] as? String
   }
   
+
   init(ref: String = "",
        topic: String = "",
        event: String = "",
@@ -54,7 +63,7 @@ public class Message {
     self.ref = ref
     self.topic = topic
     self.event = event
-    self.payload = payload
+    self.rawPayload = payload
     self.joinRef = joinRef
   }
   
@@ -69,7 +78,7 @@ public class Message {
       
       self.topic = topic
       self.event = event
-      self.payload = payload
+      self.rawPayload = payload
     } else {
       return nil
     }

--- a/SwiftPhoenixClient.xcodeproj/project.pbxproj
+++ b/SwiftPhoenixClient.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		63B526D92656D53700289719 /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B5268D2656CFFE00289719 /* RxSwift.xcframework */; };
 		63B526DE2656D53700289719 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B526DC2656D53700289719 /* Nimble.xcframework */; };
 		63B526DF2656D53700289719 /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B526DD2656D53700289719 /* Quick.xcframework */; };
+		63DE6CCA272A2ECB00E2A728 /* MessageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DE6CC9272A2ECB00E2A728 /* MessageSpec.swift */; };
 		63F0F58D2592E44800C904FB /* ChatRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0F58C2592E44800C904FB /* ChatRoomViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -195,6 +196,7 @@
 		63B5268D2656CFFE00289719 /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
 		63B526DC2656D53700289719 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
 		63B526DD2656D53700289719 /* Quick.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Quick.xcframework; path = Carthage/Build/Quick.xcframework; sourceTree = "<group>"; };
+		63DE6CC9272A2ECB00E2A728 /* MessageSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSpec.swift; sourceTree = "<group>"; };
 		63F0F58C2592E44800C904FB /* ChatRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -393,6 +395,7 @@
 				12EF620325524B6800A6EE9B /* DefaultSerializerSpec.swift */,
 				635669C3261631DC0068B665 /* URLSessionTransportSpec.swift */,
 				63ACBE9326D53DF500171582 /* HeartbeatTimerSpec.swift */,
+				63DE6CC9272A2ECB00E2A728 /* MessageSpec.swift */,
 			);
 			path = SwiftPhoenixClientTests;
 			sourceTree = "<group>";
@@ -685,6 +688,7 @@
 				12991E15254C45FC00BB8650 /* FakeTimerQueueSpec.swift in Sources */,
 				635669C4261631DC0068B665 /* URLSessionTransportSpec.swift in Sources */,
 				12EF620725524B6800A6EE9B /* TimeoutTimerSpec.swift in Sources */,
+				63DE6CCA272A2ECB00E2A728 /* MessageSpec.swift in Sources */,
 				12EF620F25524EEF00A6EE9B /* MockableProtocol.generated.swift in Sources */,
 				12991E0F254C454C00BB8650 /* SocketSpy.swift in Sources */,
 				12991E13254C458100BB8650 /* TestHelpers.swift in Sources */,

--- a/Tests/SwiftPhoenixClientTests/MessageSpec.swift
+++ b/Tests/SwiftPhoenixClientTests/MessageSpec.swift
@@ -1,0 +1,66 @@
+//
+//  MessageSpec.swift
+//  SwiftPhoenixClientTests
+//
+//  Created by Daniel Rees on 10/27/21.
+//  Copyright © 2021 SwiftPhoenixClient. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import SwiftPhoenixClient
+
+
+class MessageSpec: QuickSpec {
+  
+  override func spec() {
+        
+    describe("json parsing") {
+      
+      it("parses a normal message") {
+        let json: [String: Any] = [
+          "event": "update",
+          "payload": [
+            "user": "James S.",
+            "message": "This is a test"
+          ],
+          "ref": "6",
+          "topic": "my-topic"
+        ]
+        
+        let message = Message(json: json)
+        expect(message?.ref).to(equal("6"))
+        expect(message?.joinRef).to(beNil())
+        expect(message?.topic).to(equal("my-topic"))
+        expect(message?.event).to(equal("update"))
+        expect(message?.payload["user"] as? String).to(equal("James S."))
+        expect(message?.payload["message"] as? String).to(equal("This is a test"))
+        expect(message?.status).to(beNil())
+      }
+      
+      it("parses a reply") {
+        let json: [String: Any] = [
+          "event": "phx_reply",
+          "payload": [
+            "response": [
+              "user": "James S.",
+              "message": "This is a test"
+            ],
+            "status": "ok"
+          ],
+          "ref": "6",
+          "topic": "my-topic"
+        ]
+        
+        let message = Message(json: json)
+        expect(message?.ref).to(equal("6"))
+        expect(message?.joinRef).to(beNil())
+        expect(message?.topic).to(equal("my-topic"))
+        expect(message?.event).to(equal("phx_reply"))
+        expect(message?.payload["user"] as? String).to(equal("James S."))
+        expect(message?.payload["message"] as? String).to(equal("This is a test"))
+        expect(message?.status).to(equal("ok"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
phoenix.js does not expose `response` and `status` to a callback when receiving a `phx_reply` from the server. This logic should remain hidden from the caller and always return the message and not the ack data.

The most simple implementation of this is to leave everything the same in `Push` and `Channel` but hide the `rawPayload` inside of `Message` and conditionally extract the `response` body if one is available