### PR TITLE
Added URLResponse to socket.onError to check for status codes

### DIFF
--- a/Examples/Basic/basic/BasicChatViewController.swift
+++ b/Examples/Basic/basic/BasicChatViewController.swift
@@ -84,8 +84,15 @@ class BasicChatViewController: UIViewController {
       }
     }
     
-    socket.delegateOnError(to: self) { (self, error) in
-      self.addText("Socket Errored: " + error.localizedDescription)
+    socket.delegateOnError(to: self) { (self, arg1) in
+      let (error, response) = arg1
+      
+      if let statusCode = (response as? HTTPURLResponse)?.statusCode, statusCode > 400 {
+        self.addText("Socket Errored: \(statusCode)")
+        self.socket.disconnect()
+      } else {
+        self.addText("Socket Errored: " + error.localizedDescription)
+      }
     }
     
     socket.logger = { msg in print("LOG:", msg) }

--- a/Examples/Basic/chatroom/ChatRoomViewController.swift
+++ b/Examples/Basic/chatroom/ChatRoomViewController.swift
@@ -133,7 +133,13 @@ class ChatRoomViewController: UIViewController {
     }
     
     socket.delegateOnError(to: self) { (self, error) in
-      print("CHAT ROOM: Socket Errored. \(error)")
+      let (error, response) = error
+      if let statusCode = (response as? HTTPURLResponse)?.statusCode, statusCode > 400 {
+        print("CHAT ROOM: Socket Errored. \(statusCode)")
+        self.socket.disconnect()
+      } else {
+        print("CHAT ROOM: Socket Errored. \(error)")
+      }
     }
     
     socket.logger = { msg in print("LOG:", msg) }


### PR DESCRIPTION
Closes #225 

The current `onError` handler only returns information regarding client-side errors when connecting a socket. In order to get an indepth look as to why a Server might have declined the connection, the `task.response` needed to also be returned to `socket.onError`

Examples have been updated to account for this case