### PR TITLE
Correct `URLSession` delegate queue

### DIFF
--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -137,10 +137,10 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   /// The URL to connect to
   internal let url: URL
   
-  /// The URLSession configuratio
+  /// The URLSession configuration
   internal let configuration: URLSessionConfiguration
     
-  /// The underling URLsession. Assigned during `connect()`
+  /// The underling URLSession. Assigned during `connect()`
   private var session: URLSession? = nil
   
   /// The ongoing task. Assigned during `connect()`
@@ -195,7 +195,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
     self.readyState = .connecting
     
     // Create the session and websocket task
-    self.session = URLSession(configuration: self.configuration, delegate: self, delegateQueue: OperationQueue())
+    self.session = URLSession(configuration: self.configuration, delegate: self, delegateQueue: nil)
     self.task = self.session?.webSocketTask(with: url)
     
     // Start the task


### PR DESCRIPTION
The [`URLSession` documentation](https://developer.apple.com/documentation/foundation/urlsession/1411597-init#parameters) notes that `delegateQueue`:
> should be a serial queue, in order to ensure the correct ordering of callbacks. If nil, the session creates a serial operation queue for performing all delegate method calls and completion handler calls

Creating a new `OperationQueue()` makes a concurrent queue which can lead to inconsistent ordering of lifecycle events. This change switches to use the default delegate queue when creating a `URLSession`.