### PR TITLE
Heartbeat timer leeway

### DIFF
--- a/Sources/SwiftPhoenixClient/Defaults.swift
+++ b/Sources/SwiftPhoenixClient/Defaults.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-/// A collection of default values and behaviors used accross the Client
+/// A collection of default values and behaviors used across the Client
 public class Defaults {
   
   /// Default timeout when sending messages
@@ -28,6 +28,9 @@ public class Defaults {
   
   /// Default interval to send heartbeats on
   public static let heartbeatInterval: TimeInterval = 30.0
+
+  /// Default maximum amount of time which the system may delay heartbeat events in order to minimize power usage
+  public static let heartbeatLeeway: DispatchTimeInterval = .milliseconds(10)
   
   /// Default reconnect algorithm for the socket
   public static let reconnectSteppedBackOff: (Int) -> TimeInterval = { tries in

--- a/Sources/SwiftPhoenixClient/HeartbeatTimer.swift
+++ b/Sources/SwiftPhoenixClient/HeartbeatTimer.swift
@@ -24,7 +24,7 @@ import Foundation
 
 /**
  Heartbeat Timer class which manages the lifecycle of the underlying
- timer which triggers when a hearbeat should be fired. This heartbeat
+ timer which triggers when a heartbeat should be fired. This heartbeat
  runs on it's own Queue so that it does not interfere with the main
  queue but guarantees thread safety.
  */
@@ -36,6 +36,9 @@ class HeartbeatTimer {
   //----------------------------------------------------------------------
   // The interval to wait before firing the Timer
   let timeInterval: TimeInterval
+
+  /// The maximum amount of time which the system may delay the delivery of the timer events
+  let leeway: DispatchTimeInterval
   
   // The DispatchQueue to schedule the timers on
   let queue: DispatchQueue
@@ -54,12 +57,15 @@ class HeartbeatTimer {
   /**
    Create a new HeartbeatTimer
    
-   - Parameter timeInterval: Interval to fire the timer. Repeats
-   - parameter queue: Queue to schedule the timer on
+   - Parameters:
+     - timeInterval: Interval to fire the timer. Repeats
+     - queue: Queue to schedule the timer on
+     - leeway: The maximum amount of time which the system may delay the delivery of the timer events
    */
-  init(timeInterval: TimeInterval, queue: DispatchQueue) {
+  init(timeInterval: TimeInterval, queue: DispatchQueue = Defaults.heartbeatQueue, leeway: DispatchTimeInterval = Defaults.heartbeatLeeway) {
     self.timeInterval = timeInterval
     self.queue = queue
+    self.leeway = leeway
   }
   
   /**
@@ -80,7 +86,8 @@ class HeartbeatTimer {
       // Schedule the timer to first fire in `timeInterval` and then
       // repeat every `timeInterval`
       timer.schedule(deadline: DispatchTime.now() + self.timeInterval,
-                     repeating: self.timeInterval)
+                     repeating: self.timeInterval,
+                     leeway: self.leeway)
       
       // Start the timer
       timer.resume()


### PR DESCRIPTION
This PR adds an option to specify the heartbeat timer’s leeway. Timer leeway enables system flexibility for when a timer fires - increasing the ability of the system to optimize for increased power savings and responsiveness.