### PR TITLE
Converts Socket's stateChangeCallbacks arrays to SynchronizedArrays

### DIFF
--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -36,10 +36,10 @@ public typealias PayloadClosure = () -> Payload?
 
 /// Struct that gathers callbacks assigned to the Socket
 struct StateChangeCallbacks {
-  var open: [(ref: String, callback: Delegated<Void, Void>)] = []
-  var close: [(ref: String, callback: Delegated<Void, Void>)] = []
-  var error: [(ref: String, callback: Delegated<(Error, URLResponse?), Void>)] = []
-  var message: [(ref: String, callback: Delegated<Message, Void>)] = []
+  var open: SynchronizedArray<(ref: String, callback: Delegated<Void, Void>)> = .init()
+  var close: SynchronizedArray<(ref: String, callback: Delegated<Void, Void>)> = .init()
+  var error: SynchronizedArray<(ref: String, callback: Delegated<(Error, URLResponse?), Void>)> = .init()
+  var message: SynchronizedArray<(ref: String, callback: Delegated<Message, Void>)> = .init()
 }
 
 
@@ -458,7 +458,7 @@ public class Socket: PhoenixTransportDelegate {
     return self.append(callback: delegated, to: &self.stateChangeCallbacks.message)
   }
   
-  private func append<T>(callback: T, to array: inout [(ref: String, callback: T)]) -> String {
+  private func append<T>(callback: T, to array: inout SynchronizedArray<(ref: String, callback: T)>) -> String {
     let ref = makeRef()
     array.append((ref, callback))
     return ref

--- a/Sources/SwiftPhoenixClient/SynchronizedArray.swift
+++ b/Sources/SwiftPhoenixClient/SynchronizedArray.swift
@@ -25,9 +25,25 @@ public class SynchronizedArray<Element> {
         }
     }
     
-    func filter(_ isIncluded: (Element) -> Bool) -> [Element] {
-        var result = [Element]()
-        queue.sync { result = self.array.filter(isIncluded) }
+    func removeAll() {
+        queue.async(flags: .barrier) {
+            self.array.removeAll()
+        }
+    }
+    
+    func forEach(_ body: @escaping (Element) -> Void) {
+        queue.async(flags: .barrier) {
+            self.array.forEach(body)
+        }
+    }
+    
+    func filter(_ isIncluded: (Element) -> Bool) -> SynchronizedArray<Element> {
+        var result = SynchronizedArray<Element>()
+        queue.sync {
+            self.array.filter(isIncluded).forEach {
+                result.append($0)
+            }
+        }
         return result
     }
 }

--- a/Sources/SwiftPhoenixClient/SynchronizedArray.swift
+++ b/Sources/SwiftPhoenixClient/SynchronizedArray.swift
@@ -38,7 +38,7 @@ public class SynchronizedArray<Element> {
     }
     
     func filter(_ isIncluded: (Element) -> Bool) -> SynchronizedArray<Element> {
-        var result = SynchronizedArray<Element>()
+        let result = SynchronizedArray<Element>()
         queue.sync {
             self.array.filter(isIncluded).forEach {
                 result.append($0)


### PR DESCRIPTION
### Issue:
If a socket action is dispatched asynchronously, `SwiftPhoenixClient` sometimes crashes on line 463 of `Socket.swift` when one of the `stateChangeCallback` arrays is changed asynchronously.

<img width="1037" alt="Screenshot 2023-05-09 at 6 36 09 PM" src="https://github.com/davidstump/SwiftPhoenixClient/assets/42417496/3a4f7843-e14f-4edf-a2d2-66dedacb960d">
<img width="808" alt="Screenshot 2023-05-10 at 10 13 38 AM" src="https://github.com/davidstump/SwiftPhoenixClient/assets/42417496/00c126ec-525d-4fe8-b858-ee3755bca652">

### Solution:
This PR takes the same approach that was taken to achieve thread-safe access to the `bindingsDel` array [here](https://github.com/davidstump/SwiftPhoenixClient/pull/236).