### PR TITLE
Expose list of channels for each socket

### DIFF
--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -140,7 +140,7 @@ public class Socket: PhoenixTransportDelegate {
   var stateChangeCallbacks: StateChangeCallbacks = StateChangeCallbacks()
   
   /// Collection on channels created for the Socket
-  var channels: [Channel] = []
+  public internal(set) var channels: [Channel] = []
   
   /// Buffers messages that need to be sent once the socket has connected. It is an array
   /// of tuples, with the ref of the message to send and the callback that will send the message.


### PR DESCRIPTION
### Context:
There are use cases where it's important to access existing channel instances. While it's possible to keep a local reference of joined channels, it would be safer and less error-prone for apps to be able to access a `Socket`'s `channels` array directly.

### Specific issue:
*Note: this PR only allows clients using `SwiftPhoenixClient` to put in place a workaround, it doesn't actually fix what I believe is a bug.*

This week I encountered a scenario in which a locally kept list of channels would get out of sync with the one kept by the `Socket` even without an obvious user error:
- A channel is removed from the local array when a `Push` returned from `Channel.leave()` receives an "ok" status
- The app attempts to leave a channel while offline
- The `Channel` can't push events without an active internet connection, so it's never officially closed
- Unfortunately, `Channel.leave()` triggers an automatic success if `canPush` is false. This leads the app to believe that a channel was left successfully.
<img width="663" alt="Screenshot 2023-05-12 at 5 04 00 PM" src="https://github.com/davidstump/SwiftPhoenixClient/assets/42417496/9c49da61-0962-4a51-99b2-58a49942d6cd">

