### PR TITLE
Pass response in `onOpen` callback

### DIFF
--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -69,8 +69,10 @@ public protocol PhoenixTransportDelegate {
   
   /**
    Notified when the `Transport` opens.
+   
+   - Parameter response: Response from the server indicating that the WebSocket handshake was successful and the connection has been upgraded to webSockets
    */
-  func onOpen()
+  func onOpen(response: URLResponse?)
   
   /**
    Notified when the `Transport` receives an error.
@@ -232,7 +234,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
                        didOpenWithProtocol protocol: String?) {
     // The Websocket is connected. Set Transport state to open and inform delegate
     self.readyState = .open
-    self.delegate?.onOpen()
+    self.delegate?.onOpen(response: webSocketTask.response)
     
     // Start receiving messages
     self.receive()


### PR DESCRIPTION
The response may be useful for the clients for diagnosis and observability. 
E.g., it enables extracting a Cloudflare Ray id from the HTTP headers.

`onOpen` methods with no value passed to the callback are preserved for backward compatibility.