### PR TITLE
Break Socket retain cycle

### DIFF
--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -604,7 +604,8 @@ public class Socket: PhoenixTransportDelegate {
                      ref: String? = nil,
                      joinRef: String? = nil) {
     
-    let callback: (() throws -> ()) = {
+    let callback: (() throws -> ()) = { [weak self] in
+      guard let self else { return }
       let body: [Any?] = [joinRef, ref, topic, event, payload]
       let data = self.encode(body)
       


### PR DESCRIPTION
When a message was send to the `Socket` instance when it was disconnected, and the socket reference was removed:
* **Currently**: the socket stays in memory due to the retain cycle in `sendBuffer`.
* **With this change**: the socket is removed from memory.