### PR TITLE
Task/support request headers for socket connection

### DIFF
--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -40,7 +40,7 @@ public protocol PhoenixTransport {
    Connect to the server
    */
   func connect(with headers: [String : Any])
-    
+  
   /**
    Disconnect from the server.
    
@@ -206,7 +206,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
     // Start the task
     self.task?.resume()
   }
-    
+  
   open func disconnect(code: Int, reason: String?) {
     /*
      TODO:

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -39,11 +39,6 @@ public protocol PhoenixTransport {
   /**
    Connect to the server
    */
-  func connect()
-  
-  /**
-   Connect to the server with request headers
-   */
   func connect(with headers: [String : Any])
     
   /**
@@ -195,19 +190,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   public var readyState: PhoenixTransportReadyState = .closed
   public var delegate: PhoenixTransportDelegate? = nil
   
-  open func connect() {
-    // Set the transport state as connecting
-    self.readyState = .connecting
-    
-    // Create the session and websocket task
-    self.session = URLSession(configuration: self.configuration, delegate: self, delegateQueue: nil)
-    self.task = self.session?.webSocketTask(with: url)
-    
-    // Start the task
-    self.task?.resume()
-  }
-  
-  open func connect(with headers: [String : Any]) {
+  open func connect(with headers: [String : Any] = [:]) {
     // Set the transport state as connecting
     self.readyState = .connecting
     

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -42,6 +42,11 @@ public protocol PhoenixTransport {
   func connect()
   
   /**
+   Connect to the server
+   */
+  func connect(with headers: [String : Any])
+    
+  /**
    Disconnect from the server.
    
    - Parameters:
@@ -202,6 +207,23 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
     self.task?.resume()
   }
   
+  open func connect(with headers: [String : Any]) {
+    // Set the transport state as connecting
+    self.readyState = .connecting
+    
+    // Create the session, request, and websocket task
+    self.session = URLSession(configuration: self.configuration, delegate: self, delegateQueue: nil)
+    var request = URLRequest(url: url)
+    for header in headers {
+        guard let value = header.value as? String else { return }
+        request.addValue(value, forHTTPHeaderField: header.key)
+    }
+    self.task = self.session?.webSocketTask(with: request)
+    
+    // Start the task
+    self.task?.resume()
+  }
+    
   open func disconnect(code: Int, reason: String?) {
     /*
      TODO:

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -42,7 +42,7 @@ public protocol PhoenixTransport {
   func connect()
   
   /**
-   Connect to the server
+   Connect to the server with request headers
    */
   func connect(with headers: [String : Any])
     

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -97,6 +97,9 @@ public class Socket: PhoenixTransportDelegate {
   
   /// Timeout to use when opening connections
   public var timeout: TimeInterval = Defaults.timeoutInterval
+    
+  /// Custom headers to be added to the socket connection request
+  public var headers: [String : Any] = [:]
   
   /// Interval between sending a heartbeat
   public var heartbeatInterval: TimeInterval = Defaults.heartbeatInterval
@@ -171,6 +174,7 @@ public class Socket: PhoenixTransportDelegate {
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   public convenience init(_ endPoint: String,
                           params: Payload? = nil,
+                          headers: [String : Any] = [:],
                           vsn: String = Defaults.vsn) {
     self.init(endPoint: endPoint,
               transport: { url in return URLSessionTransport(url: url) },
@@ -181,6 +185,7 @@ public class Socket: PhoenixTransportDelegate {
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   public convenience init(_ endPoint: String,
                           paramsClosure: PayloadClosure?,
+                          headers: [String : Any] = [:],
                           vsn: String = Defaults.vsn) {
     self.init(endPoint: endPoint,
               transport: { url in return URLSessionTransport(url: url) },
@@ -192,9 +197,11 @@ public class Socket: PhoenixTransportDelegate {
   public init(endPoint: String,
        transport: @escaping ((URL) -> PhoenixTransport),
        paramsClosure: PayloadClosure? = nil,
+       headers: [String : Any] = [:],
        vsn: String = Defaults.vsn) {
     self.transport = transport
     self.paramsClosure = paramsClosure
+    self.headers = headers
     self.endPoint = endPoint
     self.vsn = vsn
     self.endPointUrl = Socket.buildEndpointUrl(endpoint: endPoint,
@@ -242,9 +249,8 @@ public class Socket: PhoenixTransportDelegate {
   
   /// Connects the Socket. The params passed to the Socket on initialization
   /// will be sent through the connection as query parameters.
-  /// Any headers passed to this function will be added to the connection request.
   /// If the Socket is already connected, then this call will be ignored.
-  public func connect(with headers: [String : Any] = [:]) {
+  public func connect() {
     // Do not attempt to reconnect if the socket is currently connected
     guard !isConnected else { return }
     
@@ -267,7 +273,7 @@ public class Socket: PhoenixTransportDelegate {
 //    self.connection?.enabledSSLCipherSuites = enabledSSLCipherSuites
 //    #endif
     
-    self.connection?.connect(with: headers)
+    self.connection?.connect(with: self.headers)
   }
   
   /// Disconnects the socket

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -241,9 +241,10 @@ public class Socket: PhoenixTransportDelegate {
   }
   
   /// Connects the Socket. The params passed to the Socket on initialization
-  /// will be sent through the connection as query parameters. If the Socket is already connected,
-  /// then this call will be ignored.
-  public func connect() {
+  /// will be sent through the connection as query parameters.
+  /// Any headers passed to this function will be added to the connection request.
+  /// If the Socket is already connected, then this call will be ignored.
+  public func connect(with headers: [String : Any] = [:]) {
     // Do not attempt to reconnect if the socket is currently connected
     guard !isConnected else { return }
     
@@ -266,25 +267,6 @@ public class Socket: PhoenixTransportDelegate {
 //    self.connection?.enabledSSLCipherSuites = enabledSSLCipherSuites
 //    #endif
     
-    self.connection?.connect()
-  }
-    
-  /// Connects the Socket. The params passed to the Socket on initialization
-  /// will be sent through the connection. The headers passed to this function will be added to the connection request.
-  /// If the Socket is already connected, then this call will be ignored.
-  public func connect(with headers: [String : Any]) {
-    // Do not attempt to reconnect if the socket is currently connected
-    guard !isConnected else { return }
-    
-    // Reset the close status when attempting to connect
-    self.closeStatus = .unknown
-    // We need to build this right before attempting to connect as the
-    // parameters could be built upon demand and change over time
-    self.endPointUrl = Socket.buildEndpointUrl(endpoint: self.endPoint,
-                                               paramsClosure: self.paramsClosure,
-                                               vsn: vsn)
-    self.connection = self.transport(self.endPointUrl)
-    self.connection?.delegate = self
     self.connection?.connect(with: headers)
   }
   

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -179,6 +179,7 @@ public class Socket: PhoenixTransportDelegate {
     self.init(endPoint: endPoint,
               transport: { url in return URLSessionTransport(url: url) },
               paramsClosure: { params },
+              headers: headers,
               vsn: vsn)
   }
 
@@ -190,6 +191,7 @@ public class Socket: PhoenixTransportDelegate {
     self.init(endPoint: endPoint,
               transport: { url in return URLSessionTransport(url: url) },
               paramsClosure: paramsClosure,
+              headers: headers,
               vsn: vsn)
   }
   

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -241,7 +241,7 @@ public class Socket: PhoenixTransportDelegate {
   }
   
   /// Connects the Socket. The params passed to the Socket on initialization
-  /// will be sent through the connection. If the Socket is already connected,
+  /// will be sent through the connection as query parameters. If the Socket is already connected,
   /// then this call will be ignored.
   public func connect() {
     // Do not attempt to reconnect if the socket is currently connected
@@ -267,6 +267,25 @@ public class Socket: PhoenixTransportDelegate {
 //    #endif
     
     self.connection?.connect()
+  }
+    
+  /// Connects the Socket. The params passed to the Socket on initialization
+  /// will be sent through the connection. The headers passed to this function will be added to the connection request.
+  /// If the Socket is already connected, then this call will be ignored.
+  public func connect(with headers: [String : Any]) {
+    // Do not attempt to reconnect if the socket is currently connected
+    guard !isConnected else { return }
+    
+    // Reset the close status when attempting to connect
+    self.closeStatus = .unknown
+    // We need to build this right before attempting to connect as the
+    // parameters could be built upon demand and change over time
+    self.endPointUrl = Socket.buildEndpointUrl(endpoint: self.endPoint,
+                                               paramsClosure: self.paramsClosure,
+                                               vsn: vsn)
+    self.connection = self.transport(self.endPointUrl)
+    self.connection?.delegate = self
+    self.connection?.connect(with: headers)
   }
   
   /// Disconnects the socket


### PR DESCRIPTION
The framework currently doesn't support using a `URLRequest` with custom headers for the socket connection request.

This PR adds the ability to open a socket via a `URLRequest` with custom headers by making use of `URLSession`'s `webSocketTask(with request: URLRequest)` function.