### PR TITLE
Prevent crashes caused by threading issues

### DIFF
--- a/Sources/SwiftPhoenixClient/Channel.swift
+++ b/Sources/SwiftPhoenixClient/Channel.swift
@@ -75,7 +75,7 @@ public class Channel {
   var state: ChannelState
   
   /// Collection of event bindings
-  var syncBindingsDel: SynchronizedArray<Binding>
+  let syncBindingsDel: SynchronizedArray<Binding>
   
   /// Tracks event binding ref counters
   var bindingRef: Int
@@ -572,9 +572,11 @@ public class Channel {
   func trigger(_ message: Message) {
     let handledMessage = self.onMessage(message)
     
-    self.syncBindingsDel
-      .filter( { return $0.event == message.event } )
-      .forEach( { $0.callback.call(handledMessage) } )
+    self.syncBindingsDel.forEach { binding in
+        if binding.event == message.event {
+            binding.callback.call(handledMessage)
+        }
+    }
   }
   
   /// Triggers an event to the correct event bindings created by

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -147,7 +147,7 @@ public class Socket: PhoenixTransportDelegate {
   
   /// Buffers messages that need to be sent once the socket has connected. It is an array
   /// of tuples, with the ref of the message to send and the callback that will send the message.
-  var sendBuffer: [(ref: String?, callback: () throws -> ())] = []
+  let sendBuffer = SynchronizedArray<(ref: String?, callback: () throws -> ())>()
   
   /// Ref counter for messages
   var ref: UInt64 = UInt64.min // 0 (max: 18,446,744,073,709,551,615)
@@ -730,9 +730,9 @@ public class Socket: PhoenixTransportDelegate {
   
   /// Send all messages that were buffered before the socket opened
   internal func flushSendBuffer() {
-    guard isConnected && sendBuffer.count > 0 else { return }
+    guard isConnected else { return }
     self.sendBuffer.forEach( { try? $0.callback() } )
-    self.sendBuffer = []
+    self.sendBuffer.removeAll()
   }
   
   /// Removes an item from the sendBuffer with the matching ref

--- a/Sources/SwiftPhoenixClient/SynchronizedArray.swift
+++ b/Sources/SwiftPhoenixClient/SynchronizedArray.swift
@@ -11,12 +11,9 @@ import Foundation
 /// A thread-safe array.
 public class SynchronizedArray<Element> {
     fileprivate let queue = DispatchQueue(label: "spc_sync_array", attributes: .concurrent)
-    fileprivate var array = [Element]()
-
-    public init() { }
-        
-    public convenience init(_ array: [Element]) {
-        self.init()
+    fileprivate var array: [Element]
+    
+    public init(_ array: [Element] = []) {
         self.array = array
     }
     
@@ -26,15 +23,9 @@ public class SynchronizedArray<Element> {
         }
     }
     
-    func filter(_ isIncluded: @escaping (Element) -> Bool) -> SynchronizedArray {
-        var result: SynchronizedArray?
-        queue.sync { result = SynchronizedArray(self.array.filter(isIncluded)) }
-        return result!
-    }
-    
     func forEach(_ body: (Element) -> Void) {
-            queue.sync { self.array.forEach(body) }
-        }
+        queue.sync { self.array }.forEach(body)
+    }
     
     func removeAll() {
         queue.async(flags: .barrier) {


### PR DESCRIPTION
### Overview
This PR addresses a few crashes caused by threading issues in array mutation.  The symptoms of these crashes are EXC_BREAKPOINT, SIGABRT ABORT, and EXC_BAD_ACCESS KERN_INVALID_ADDRESS exceptions on the `spc_sync_array` thead. The exceptions have the following details:

* > Object of class SynchronizedArray deallocated with non-zero retain count 3. This object's deinit, or something called from it, may have created a strong reference to self which outlived deinit, resulting in a dangling reference.
* > malloc: Non-aligned pointer being freed (2)
* > malloc: double free for ptr

<img width="943" alt="CrashLog" src="https://github.com/davidstump/SwiftPhoenixClient/assets/915431/bf1a571f-5575-48b2-8087-1e1779e83ebe">

### Issues being addressed
1. Instances of the `SychronizedArray` class were being replaced rather than updated. Replacing the instances of `SychronizedArray` removes the safety the `SychronizedArray` type provides. It also results in the `spc_sync_array` dispatch queue the `SychronizedArray` owns to become unowned when the `SychronizedArray` class deallocates, causing SIGABRT ABORT and EXC_BAD_ACCESS KERN_INVALID_ADDRESS exceptions
  * This issue is addressed by making `SychronizedArray` instances `let`s and using the synchronized functions of `SychronizedArray` to update the underlying array variable
2. The `sendBuffer` array was being mutated on multiple threads causing EXC_BREAKPOINT exceptions
  * This issue is addressed by using `SychronizedArray`