### PR TITLE
Prevent crash caused by non-exclusive access to the Channels array

### DIFF
--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -143,7 +143,8 @@ public class Socket: PhoenixTransportDelegate {
   let stateChangeCallbacks: StateChangeCallbacks = StateChangeCallbacks()
   
   /// Collection on channels created for the Socket
-  public internal(set) var channels: [Channel] = []
+  public var channels: [Channel] { _channels.copy() }
+  private var _channels = SynchronizedArray<Channel>()
   
   /// Buffers messages that need to be sent once the socket has connected. It is an array
   /// of tuples, with the ref of the message to send and the callback that will send the message.
@@ -557,7 +558,7 @@ public class Socket: PhoenixTransportDelegate {
   public func channel(_ topic: String,
                       params: [String: Any] = [:]) -> Channel {
     let channel = Channel(topic: topic, params: params, socket: self)
-    self.channels.append(channel)
+    _channels.append(channel)
     
     return channel
   }
@@ -574,7 +575,7 @@ public class Socket: PhoenixTransportDelegate {
   /// - parameter channel: Channel to remove
   public func remove(_ channel: Channel) {
     self.off(channel.stateChangeRefs)
-    self.channels.removeAll(where: { $0.joinRef == channel.joinRef })
+    _channels.removeAll(where: { $0.joinRef == channel.joinRef })
   }
   
   /// Removes `onOpen`, `onClose`, `onError,` and `onMessage` registrations.
@@ -710,17 +711,19 @@ public class Socket: PhoenixTransportDelegate {
     }
     
     // Dispatch the message to all channels that belong to the topic
-    self.channels
-      .filter( { $0.isMember(message) } )
-      .forEach( { $0.trigger(message) } )
-    
+    _channels.forEach { channel in
+      if channel.isMember(message) {
+        channel.trigger(message)
+      }
+    }
+
     // Inform all onMessage callbacks of the message
     self.stateChangeCallbacks.message.forEach({ $0.callback.call(message) })
   }
   
   /// Triggers an error event to all of the connected Channels
   internal func triggerChannelError() {
-    self.channels.forEach { (channel) in
+    _channels.forEach { channel in
       // Only trigger a channel error if it is in an "opened" state
       if !(channel.isErrored || channel.isLeaving || channel.isClosed) {
         channel.trigger(event: ChannelEvent.error)
@@ -777,7 +780,7 @@ public class Socket: PhoenixTransportDelegate {
   // Leaves any channel that is open that has a duplicate topic
   internal func leaveOpenTopic(topic: String) {
     guard
-      let dupe = self.channels.first(where: { $0.topic == topic && ($0.isJoined || $0.isJoining) })
+      let dupe = _channels.first(where: { $0.topic == topic && ($0.isJoined || $0.isJoining) })
     else { return }
     
     self.logItems("transport", "leaving duplicate topic: [\(topic)]" )

--- a/Sources/SwiftPhoenixClient/SynchronizedArray.swift
+++ b/Sources/SwiftPhoenixClient/SynchronizedArray.swift
@@ -17,10 +17,18 @@ public class SynchronizedArray<Element> {
         self.array = array
     }
     
+    public func copy() -> [Element] {
+        queue.sync { self.array }
+    }
+    
     func append( _ newElement: Element) {
         queue.async(flags: .barrier) {
             self.array.append(newElement)
         }
+    }
+    
+    func first(where predicate: (Element) -> Bool) -> Element? {
+        queue.sync { self.array.first(where: predicate) }
     }
     
     func forEach(_ body: (Element) -> Void) {


### PR DESCRIPTION
This PR fixes a threading issue where the `Socket.channels` array is being mutated while it is being iterated. This PR wraps `channels` in a `SynchronizedArray` to resolve this issue.

Crash stack trace:
```
SIGTRAP

Crashed: com.apple.NSURLSession-delegate
0  Frame.io                   0x1779e18 specialized _ArrayProtocol.filter(_:) + 714 (Socket.swift:714)
1  Frame.io                   0x17765a0 Socket.onConnectionMessage(_:) + 713 (Socket.swift:713)
2  Frame.io                   0x1777d84 protocol witness for PhoenixTransportDelegate.onMessage(message:) in conformance Socket + 860 (Socket.swift:860)
3  Frame.io                   0x1768e34 closure #1 in URLSessionTransport.receive() + 283 (PhoenixTransport.swift:283)
4  Foundation                 0x3aadec closure #1 in NSURLSessionWebSocketTask.receive(completionHandler:) + 144
5  Foundation                 0x3aaf80 thunk for @escaping @callee_guaranteed @Sendable (@guaranteed NSURLSessionWebSocketMessage?, @guaranteed Error?) -> () + 84
6  libdispatch.dylib          0x213c _dispatch_call_block_and_release + 32
7  libdispatch.dylib          0x3dd4 _dispatch_client_callout + 20
8  libdispatch.dylib          0xb400 _dispatch_lane_serial_drain + 748
9  libdispatch.dylib          0xbf64 _dispatch_lane_invoke + 432
10 libdispatch.dylib          0x16cb4 _dispatch_root_queue_drain_deferred_wlh + 288
11 libdispatch.dylib          0x16528 _dispatch_workloop_worker_thread + 404
12 libsystem_pthread.dylib    0x1f20 _pthread_wqthread + 288
13 libsystem_pthread.dylib    0x1fc0 start_wqthread + 8
```