### PR TITLE
fix crashes from `Socket.connect` race conditions

### DIFF
--- a/Sources/SwiftPhoenixClient/HeartbeatTimer.swift
+++ b/Sources/SwiftPhoenixClient/HeartbeatTimer.swift
@@ -78,7 +78,9 @@ class HeartbeatTimer {
   }
   
   func start(eventHandler: @escaping () -> Void) {
-    queue.sync {
+    queue.sync { [weak self] in
+      
+      guard let self else { return }
       // Create a new DispatchSourceTimer, passing the event handler
       let timer = DispatchSource.makeTimerSource(flags: [], queue: queue)
       timer.setEventHandler(handler: eventHandler)
@@ -98,10 +100,11 @@ class HeartbeatTimer {
   
   func stop() {
     // Must be queued synchronously to prevent threading issues.
-    queue.sync {
+    queue.sync { [weak self] in
+      guard let self else { return }
       // DispatchSourceTimer will automatically cancel when released
-      temporaryTimer = nil
-      temporaryEventHandler = nil
+        self.temporaryTimer = nil
+        self.temporaryEventHandler = nil
     }
   }
   

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -267,11 +267,9 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
     // if this was caused by an error.
     guard let err = error else { return }
       
-    if let nsError = err as NSError? {
+    if let urlError = err as? URLError, urlError.code == .cancelled {
         // If the client cancels a task, don't treat it as an abnormal error
-        if nsError.domain == "NSURLErrorDomain" && nsError.code == NSURLErrorCancelled {
-            return
-        }
+        return
     }
     
     self.abnormalErrorReceived(err, response: task.response)

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -260,6 +260,7 @@ public class Socket: PhoenixTransportDelegate {
                                                paramsClosure: self.paramsClosure,
                                                vsn: vsn)
 
+    self.connection?.disconnect(code: CloseCode.normal.rawValue, reason: "connect called")
     self.connection = self.transport(self.endPointUrl)
     self.connection?.delegate = self
 //    self.connection?.disableSSLCertValidation = disableSSLCertValidation

--- a/Tests/SwiftPhoenixClientTests/SocketSpec.swift
+++ b/Tests/SwiftPhoenixClientTests/SocketSpec.swift
@@ -268,6 +268,17 @@ class SocketSpec: QuickSpec {
         
         expect(mockWebSocket.connectCallsCount).to(equal(1))
       })
+        
+        
+    it("disconnects from old socket before connecting to a new one", closure: {
+      mockWebSocket.readyState = .connecting
+      
+      socket.connect()
+      socket.connect()
+      
+      expect(mockWebSocket.disconnectCodeReasonCallsCount).to(equal(1))
+      expect(mockWebSocket.connectCallsCount).to(equal(2))
+    })
     }
     
     


### PR DESCRIPTION
Includes fixes for two flavors of issues we've encountered in our SwiftUI application. 

1. https://github.com/davidstump/SwiftPhoenixClient/issues/253 
This one I'm having trouble reproducing locally, but the `Object 0x303285e60 of class HeartbeatTimer deallocated with non-zero retain count 3. This object's deinit, or something called from it, may have created a strong reference to self which outlived deinit, resulting in a dangling reference` error especially had me thinking it was an issue with a strong reference in HeartbeatTimer. Please let me know if there is a good way to test this!

2. https://github.com/davidstump/SwiftPhoenixClient/issues/258 - `Error when receiving Error Domain=NSPOSIXErrorDomain Code=57 "Socket is not connected"` Error messages
* Only log `failure` error messages if `self` is not nil in `PhoenixTransport.receive`
* Disconnect the existing connection in `Socket.connect` so that old connections are cleaned up.
* Ignore errors due to normal cancellations


Tested these changes in an app that calls `socket.connect()` twice whenever returning from the background and confirmed `onOpen` callback only invoked once and `onError` not invoked.


