### PR TITLE
PhoenixTransport Crash Fix for iOS 18

### DIFF
--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -151,7 +151,13 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   
   /// The ongoing task. Assigned during `connect()`
   private var task: URLSessionWebSocketTask? = nil
-  
+
+  /// Holds the current receive task
+  private var receiveMesageTask: Task<Void, Never>? {
+      didSet {
+          oldValue?.cancel()
+      }
+  }
   
   /**
    Initializes a `Transport` layer built using URLSession's WebSocket
@@ -192,6 +198,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   
   deinit {
     self.delegate = nil
+    receiveMesageTask?.cancel()
   }
   
   
@@ -276,29 +283,28 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   
   // MARK: - Private
   private func receive() {
-    self.task?.receive { [weak self] result in
-      guard let self = self else { return }
-        
-      switch result {
-      case .success(let message):
-        switch message {
-        case .data:
-          print("Data received. This method is unsupported by the Client")
-        case .string(let text):
-          self.delegate?.onMessage(message: text)
-        default:
-          fatalError("Unknown result was received. [\(result)]")
-        }
-        
-        // Since `.receive()` is only good for a single message, it must
-        // be called again after a message is received in order to
-        // received the next message.
-        self.receive()
-      case .failure(let error):
-        print("Error when receiving \(error)")
-        self.abnormalErrorReceived(error, response: nil)
+    receiveMesageTask = Task { [weak self] in
+      guard let self else { return }
+        do {
+            let message = try await task?.receive()
+            switch message {
+            case .data:
+                print("Data received. This method is unsupported by the Client")
+            case .string(let text):
+                delegate?.onMessage(message: text)
+            default:
+                fatalError("Nil message received.")
+            }
+              
+            // Since `.receive()` is only good for a single message, it must
+            // be called again after a message is received in order to
+            // received the next message.
+            receive()
+          } catch {
+              print("Error when receiving \(error)")
+              abnormalErrorReceived(error, response: nil)
+          }
       }
-    }
   }
   
   private func abnormalErrorReceived(_ error: Error, response: URLResponse?) {

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -238,9 +238,9 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
     }
     
     self.readyState = .closing
-    receiveMessageTask?.cancel()
     self.task?.cancel(with: closeCode, reason: reason?.data(using: .utf8))
     self.session?.finishTasksAndInvalidate()
+    receiveMessageTask?.cancel()
   }
   
   open func send(data: Data) {

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -153,7 +153,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   private var task: URLSessionWebSocketTask? = nil
 
   /// Holds the current receive task
-  private var receiveMesageTask: Task<Void, Never>? {
+  private var receiveMessageTask: Task<Void, Never>? {
       didSet {
           oldValue?.cancel()
       }
@@ -198,7 +198,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   
   deinit {
     self.delegate = nil
-    receiveMesageTask?.cancel()
+    receiveMessageTask?.cancel()
   }
   
   
@@ -283,7 +283,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
   
   // MARK: - Private
   private func receive() {
-    receiveMesageTask = Task { [weak self] in
+    receiveMessageTask = Task { [weak self] in
       guard let self else { return }
         do {
             let message = try await task?.receive()

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -238,6 +238,7 @@ open class URLSessionTransport: NSObject, PhoenixTransport, URLSessionWebSocketD
     }
     
     self.readyState = .closing
+    receiveMessageTask?.cancel()
     self.task?.cancel(with: closeCode, reason: reason?.data(using: .utf8))
     self.session?.finishTasksAndInvalidate()
   }


### PR DESCRIPTION
## Problem
Since the release of iOS 18, we've been experiencing a significant number of crashes related to WebSocket connections. The issue was first reported in October 2024 ([Issue #267](https://github.com/davidstump/SwiftPhoenixClient/issues/267)) and appears to be specifically related to the `NSURLSessionWebSocketTask.receive(completionHandler:)` method.

## Solution
- Replaced the completion handler-based receive implementation with an async/await pattern
- Implemented proper task cancellation to prevent memory leaks

This approach aligns with the solution implemented by SendBird for a similar issue in their SDK ([reference](https://community.sendbird.com/t/sessionwebsocketengine-ios-18-crash/10127/5)).

## Testing and Validation
- Tested with the demo project
- Validated in production environment with our application
- All WebSocket functionalities (connection, message receiving, disconnection) working as expected

Looking forward to your review and feedback. This should resolve the iOS 18 crash issues. 🚀