### PR TITLE
A couple small fixes to 6.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "SwiftPhoenixClient",
     platforms: [
-        .macOS(.v10_12),
-        .iOS(.v10),
-        .tvOS(.v10),
-        .watchOS(.v3)
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,6 @@ let package = Package(
         .macOS(.v10_15),
         .iOS(.v13),
         .tvOS(.v13),
-        .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/SwiftPhoenixClient/Message.swift
+++ b/Sources/SwiftPhoenixClient/Message.swift
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import Foundation
+
 ///
 /// Defines a message dispatched over client to channels and vice-versa.
 ///

--- a/Sources/SwiftPhoenixClient/PhoenixTransport.swift
+++ b/Sources/SwiftPhoenixClient/PhoenixTransport.swift
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import Foundation
 
 //----------------------------------------------------------------------
 // MARK: - Transport Protocol

--- a/Sources/SwiftPhoenixClient/Serialization/Serializer.swift
+++ b/Sources/SwiftPhoenixClient/Serialization/Serializer.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2024 SwiftPhoenixClient. All rights reserved.
 //
 
+import Foundation
+
 /// Converts JSON received from the server into Messages and Messages into JSON to be sent to
 /// the Server
 public protocol Serializer {

--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import Foundation
 
 /// Alias for a JSON dictionary [String: Any]
 public typealias Payload = [String: Any]

--- a/SwiftPhoenixClient.podspec
+++ b/SwiftPhoenixClient.podspec
@@ -15,11 +15,6 @@ Pod::Spec.new do |s|
   SwiftPhoenixClient is a Swift port of phoenix.js, abstracting away the details
   of the Phoenix Channels library and providing a near identical experience
   to connect to your Phoenix WebSockets on iOS.
-
-  RxSwift extensions exist as well when subscribing to channel events.
-
-  A default Transport layer is implmenented for iOS 13 or later. If targeting
-  an earlier iOS version, please see the StarscreamSwiftPhoenixClient extention.
   EOS
   s.homepage         = "https://github.com/davidstump/SwiftPhoenixClient"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/SwiftPhoenixClient.podspec
+++ b/SwiftPhoenixClient.podspec
@@ -25,10 +25,9 @@ Pod::Spec.new do |s|
   s.license          = { :type => "MIT", :file => "LICENSE" }
   s.author           = { "David Stump" => "david@davidstump.net" }
   s.source           = { :git => "https://github.com/davidstump/SwiftPhoenixClient.git", :tag => s.version.to_s }
-  s.ios.deployment_target     = '11.0'
-  s.osx.deployment_target     = '10.13'
-  s.tvos.deployment_target    = '11.0'
-  s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target     = '13.0'
+  s.osx.deployment_target     = '10.15'
+  s.tvos.deployment_target    = '13.0'
 
   s.swift_version = '5.0'
   s.source_files  = "Sources/SwiftPhoenixClient/"


### PR DESCRIPTION
Two changes here:

- Add `import Foundation` in a few files that use Foundation. This fixes build errors when building as an SPM dependency.
- Update minimum versions to the minimum for URLSessionWebSocketTask and Swift Concurrency, #276 