### PR TITLE
Renamed transport layer and moved receive to concurrency

### DIFF
--- a/Sources/SwiftPhoenixClient/Socket.swift
+++ b/Sources/SwiftPhoenixClient/Socket.swift
@@ -48,7 +48,7 @@ struct StateChangeCallbacks {
 /// The `Socket` constructor takes the mount point of the socket,
 /// the authentication params, as well as options that can be found in
 /// the Socket docs, such as configuring the heartbeat.
-public class Socket: PhoenixTransportDelegate {
+public class Socket: TransportDelegate {
     
     
     //----------------------------------------------------------------------
@@ -76,7 +76,7 @@ public class Socket: PhoenixTransportDelegate {
     
     /// The WebSocket transport. Default behavior is to provide a
     /// URLSessionWebsocketTask. See README for alternatives.
-    private let transport: ((URL) -> PhoenixTransport)
+    private let transport: ((URL) -> Transport)
     
     /// Phoenix serializer version, defaults to "2.0.0"
     public var vsn: String = Defaults.vsn
@@ -147,7 +147,7 @@ public class Socket: PhoenixTransportDelegate {
     var closeStatus: URLSessionWebSocketTask.CloseCode? = nil
     
     /// The connection to the server
-    var connection: PhoenixTransport? = nil
+    var connection: Transport? = nil
     
     
     //----------------------------------------------------------------------
@@ -167,7 +167,7 @@ public class Socket: PhoenixTransportDelegate {
     
     
     public init(endPoint: String,
-                transport: @escaping ((URL) -> PhoenixTransport),
+                transport: @escaping ((URL) -> Transport),
                 params: PayloadClosure? = nil) {
         self.transport = transport
         self.paramsClosure = params
@@ -254,7 +254,7 @@ public class Socket: PhoenixTransportDelegate {
     }
     
     /// - return: The state of the connect. [.connecting, .open, .closing, .closed]
-    public var connectionState: PhoenixTransportReadyState {
+    public var connectionState: TransportReadyState {
         return self.connection?.readyState ?? .closed
     }
     

--- a/Sources/SwiftPhoenixClient/Transport/Transport.swift
+++ b/Sources/SwiftPhoenixClient/Transport/Transport.swift
@@ -1,0 +1,43 @@
+//
+//  Transport.swift
+//  SwiftPhoenixClient
+//
+//  Created by Daniel Rees on 2/2/25.
+//  Copyright © 2025 SwiftPhoenixClient. All rights reserved.
+//
+
+import Foundation
+
+/// Defines a `Socket`'s Transport layer.
+// sourcery: AutoMockable
+public protocol Transport {
+    
+    /// The current `ReadyState` of the `Transport` layer
+    var readyState: TransportReadyState { get }
+    
+    /// Delegate for the `Transport` layer
+    var delegate: TransportDelegate? { get set }
+    
+    /// Connect to the server
+    ///
+    /// - Parameters:
+    ///    - headers: Headers to include in the URLRequests when opening the Websocket connection. Can be empty [:]
+    func connect(with headers: [String: Any])
+    
+    /// Disconnect from the server.
+    ///
+    /// - Parameters:
+    ///    - code: Status code as defined by <ahref="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a>.
+    ///    - reason: Reason why the connection is closing. Optional.
+    func disconnect(code: URLSessionWebSocketTask.CloseCode, reason: String?)
+    
+    /// Sends a data message to the server.
+    ///
+    /// - Parameter data: Data to send.
+    func send(data: Data)
+    
+    /// Sends a string message to the server.
+    ///
+    /// - Parameter string: String to send.
+    func send(string: String)
+}

--- a/Sources/SwiftPhoenixClient/Transport/TransportDelegate.swift
+++ b/Sources/SwiftPhoenixClient/Transport/TransportDelegate.swift
@@ -1,0 +1,41 @@
+//
+//  TransportDelegate.swift
+//  SwiftPhoenixClient
+//
+//  Created by Daniel Rees on 2/2/25.
+//  Copyright © 2025 SwiftPhoenixClient. All rights reserved.
+//
+
+import Foundation
+
+/// Delegate to receive notifications of events that occur in the `Transport` layer.
+public protocol TransportDelegate {
+    
+    /// Notified when the `Transport` opens.
+    ///
+    /// - Parameter response: Response from the server indicating that the WebSocket
+    ///     handshake was successful and the connection has been upgraded to webSockets
+    func onOpen(response: URLResponse?)
+    
+    /// Notified when the `Transport` receives an error.
+    ///
+    /// - Parameter error: Client-side error from the underlying `Transport` implementation
+    /// - Parameter response: Response from the server, if any, that occurred with the Error
+    func onError(error: Error, response: URLResponse?)
+    
+    /// Notified when the `Transport` receives a string from the server.
+    ///
+    /// - Parameter string: String received from the server
+    func onMessage(string: String)
+    
+    /// Notified when the `Transport` receives data from the server.
+    ///
+    /// - Parameter data: Data received from the server
+    func onMessage(data: Data)
+    
+    /// Notified when the `Transport` closes.
+    ///
+    /// - Parameter code: Code that was sent when the `Transport` closed
+    /// - Parameter reason: A concise human-readable prose explanation for the closure
+    func onClose(code: URLSessionWebSocketTask.CloseCode, reason: String?)
+}

--- a/Sources/SwiftPhoenixClient/Transport/TransportReadyState.swift
+++ b/Sources/SwiftPhoenixClient/Transport/TransportReadyState.swift
@@ -1,0 +1,26 @@
+//
+//  TransportReadyState.swift
+//  SwiftPhoenixClient
+//
+//  Created by Daniel Rees on 2/2/25.
+//  Copyright © 2025 SwiftPhoenixClient. All rights reserved.
+//
+
+import Foundation
+
+/// Available `ReadyState`s of a `Transport` layer.
+public enum TransportReadyState {
+    
+    /// The `Transport` is opening a connection to the server.
+    case connecting
+    
+    /// The `Transport` is connected to the server.
+    case open
+    
+    /// The `Transport` is closing the connection to the server.
+    case closing
+    
+    /// The `Transport` has disconnected from the server.
+    case closed
+    
+}

--- a/SwiftPhoenixClient.xcodeproj/project.pbxproj
+++ b/SwiftPhoenixClient.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		1284F4D02D481E960090D0DA /* PartialMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1284F4CF2D481E960090D0DA /* PartialMessage.swift */; };
 		1284F4D22D4959E20090D0DA /* OutgoingShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1284F4D12D4959E20090D0DA /* OutgoingShape.swift */; };
 		12922E202543B10B0034B257 /* Socket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12922E1F2543B10B0034B257 /* Socket.swift */; };
-		12922E222543B37B0034B257 /* PhoenixTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12922E212543B37B0034B257 /* PhoenixTransport.swift */; };
+		12922E222543B37B0034B257 /* URLSessionTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12922E212543B37B0034B257 /* URLSessionTransport.swift */; };
 		12991DFB254C3EB800BB8650 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12991DFA254C3EB800BB8650 /* Defaults.swift */; };
 		12991DFF254C3EF900BB8650 /* HeartbeatTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12991DFE254C3EF900BB8650 /* HeartbeatTimer.swift */; };
 		12991E01254C3F1300BB8650 /* TimeoutTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12991E00254C3F1300BB8650 /* TimeoutTimer.swift */; };
@@ -53,6 +53,9 @@
 		634E20EC2CC4813D0037A570 /* PayloadEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E20EB2CC4813D0037A570 /* PayloadEncoder.swift */; };
 		635669C4261631DC0068B665 /* URLSessionTransportSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635669C3261631DC0068B665 /* URLSessionTransportSpec.swift */; };
 		63ACBE9426D53DF500171582 /* HeartbeatTimerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63ACBE9326D53DF500171582 /* HeartbeatTimerSpec.swift */; };
+		63AEB5A92D4FBBC700E8A3CC /* TransportReadyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AEB5A82D4FBBC700E8A3CC /* TransportReadyState.swift */; };
+		63AEB5AB2D4FBC0500E8A3CC /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AEB5AA2D4FBC0500E8A3CC /* Transport.swift */; };
+		63AEB5AD2D4FBC4200E8A3CC /* TransportDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AEB5AC2D4FBC4200E8A3CC /* TransportDelegate.swift */; };
 		63BBCF032B897D87004A16C9 /* TransportSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BBCF022B897D87004A16C9 /* TransportSerializer.swift */; };
 		63BBCF052B897DEF004A16C9 /* TransportSerializerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BBCF042B897DEF004A16C9 /* TransportSerializerTest.swift */; };
 		63DE6CCA272A2ECB00E2A728 /* MessageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DE6CC9272A2ECB00E2A728 /* MessageSpec.swift */; };
@@ -114,7 +117,7 @@
 		1284F4CF2D481E960090D0DA /* PartialMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartialMessage.swift; sourceTree = "<group>"; };
 		1284F4D12D4959E20090D0DA /* OutgoingShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingShape.swift; sourceTree = "<group>"; };
 		12922E1F2543B10B0034B257 /* Socket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Socket.swift; sourceTree = "<group>"; };
-		12922E212543B37B0034B257 /* PhoenixTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoenixTransport.swift; sourceTree = "<group>"; };
+		12922E212543B37B0034B257 /* URLSessionTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTransport.swift; sourceTree = "<group>"; };
 		12991DFA254C3EB800BB8650 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		12991DFE254C3EF900BB8650 /* HeartbeatTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartbeatTimer.swift; sourceTree = "<group>"; };
 		12991E00254C3F1300BB8650 /* TimeoutTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeoutTimer.swift; sourceTree = "<group>"; };
@@ -140,6 +143,9 @@
 		634E20EB2CC4813D0037A570 /* PayloadEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayloadEncoder.swift; sourceTree = "<group>"; };
 		635669C3261631DC0068B665 /* URLSessionTransportSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTransportSpec.swift; sourceTree = "<group>"; };
 		63ACBE9326D53DF500171582 /* HeartbeatTimerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartbeatTimerSpec.swift; sourceTree = "<group>"; };
+		63AEB5A82D4FBBC700E8A3CC /* TransportReadyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportReadyState.swift; sourceTree = "<group>"; };
+		63AEB5AA2D4FBC0500E8A3CC /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
+		63AEB5AC2D4FBC4200E8A3CC /* TransportDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportDelegate.swift; sourceTree = "<group>"; };
 		63B526842656CF9600289719 /* Starscream.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Starscream.xcframework; path = Carthage/Build/Starscream.xcframework; sourceTree = "<group>"; };
 		63B5268D2656CFFE00289719 /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
 		63B526DC2656D53700289719 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
@@ -235,6 +241,7 @@
 		128143AE25410DF3008615A7 /* SwiftPhoenixClient */ = {
 			isa = PBXGroup;
 			children = (
+				63AEB5A72D4FBB9000E8A3CC /* Transport */,
 				120019E32D4BA1FB00EF4613 /* Channel */,
 				1284F4CA2D4817A00090D0DA /* Message */,
 				1284F4C12D4801060090D0DA /* Parser */,
@@ -242,7 +249,6 @@
 				12991E04254C3F3300BB8650 /* Channel.swift */,
 				12991DFA254C3EB800BB8650 /* Defaults.swift */,
 				12991DFE254C3EF900BB8650 /* HeartbeatTimer.swift */,
-				12922E212543B37B0034B257 /* PhoenixTransport.swift */,
 				12991E08254C3F5B00BB8650 /* Presence.swift */,
 				12991E02254C3F2300BB8650 /* Push.swift */,
 				12922E1F2543B10B0034B257 /* Socket.swift */,
@@ -366,6 +372,17 @@
 				6343984F2CD009F800A2B9AC /* SocketTest.swift */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		63AEB5A72D4FBB9000E8A3CC /* Transport */ = {
+			isa = PBXGroup;
+			children = (
+				12922E212543B37B0034B257 /* URLSessionTransport.swift */,
+				63AEB5AA2D4FBC0500E8A3CC /* Transport.swift */,
+				63AEB5AC2D4FBC4200E8A3CC /* TransportDelegate.swift */,
+				63AEB5A82D4FBBC700E8A3CC /* TransportReadyState.swift */,
+			);
+			path = Transport;
 			sourceTree = "<group>";
 		};
 		63BBCEFE2B897AF4004A16C9 /* Serialization */ = {
@@ -558,6 +575,7 @@
 			files = (
 				12991DFB254C3EB800BB8650 /* Defaults.swift in Sources */,
 				634E20EC2CC4813D0037A570 /* PayloadEncoder.swift in Sources */,
+				63AEB5AB2D4FBC0500E8A3CC /* Transport.swift in Sources */,
 				12991E05254C3F3300BB8650 /* Channel.swift in Sources */,
 				63BBCF032B897D87004A16C9 /* TransportSerializer.swift in Sources */,
 				1284F4C02D47C8080090D0DA /* ChannelSubscription.swift in Sources */,
@@ -569,8 +587,10 @@
 				1284F4CE2D4818EF0090D0DA /* IncomingMessage.swift in Sources */,
 				12991E09254C3F5B00BB8650 /* Presence.swift in Sources */,
 				1284F4D22D4959E20090D0DA /* OutgoingShape.swift in Sources */,
+				63AEB5AD2D4FBC4200E8A3CC /* TransportDelegate.swift in Sources */,
 				12991E01254C3F1300BB8650 /* TimeoutTimer.swift in Sources */,
 				120019E52D4BA21E00EF4613 /* Channel+On.swift in Sources */,
+				63AEB5A92D4FBBC700E8A3CC /* TransportReadyState.swift in Sources */,
 				1284F4C92D48035C0090D0DA /* PayloadParser.swift in Sources */,
 				1284F4D02D481E960090D0DA /* PartialMessage.swift in Sources */,
 				12991DFF254C3EF900BB8650 /* HeartbeatTimer.swift in Sources */,
@@ -578,7 +598,7 @@
 				6343984A2CCFDDBD00A2B9AC /* PhxError.swift in Sources */,
 				1284F4C52D4801210090D0DA /* JsonPayloadParser.swift in Sources */,
 				12922E202543B10B0034B257 /* Socket.swift in Sources */,
-				12922E222543B37B0034B257 /* PhoenixTransport.swift in Sources */,
+				12922E222543B37B0034B257 /* URLSessionTransport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### What changed
* Renamed and reorganized the transport layer classes
* Moved to use `await task.receive` instead of a callback